### PR TITLE
fix: CLI pipeline produces empty resumes due to template/parser bugs

### DIFF
--- a/.claude/skills/tailor-resume/scripts/latex_renderer.py
+++ b/.claude/skills/tailor-resume/scripts/latex_renderer.py
@@ -126,6 +126,8 @@ def render_skills(skills_data) -> str:
     """
     skills_data: either a list of strings or a dict with categories.
     """
+    if not skills_data:
+        return ""
     if isinstance(skills_data, list):
         # Plain list — output as a single skills line
         skill_str = escape(", ".join(skills_data))
@@ -156,6 +158,8 @@ def render_skills(skills_data) -> str:
 
 
 def render_education(education: List[Dict]) -> str:
+    if not education:
+        return ""
     blocks = ["\\section{Education}", "  \\resumeSubHeadingListStart"]
     for edu in education:
         school = escape(edu.get("school", edu.get("institution", "")))
@@ -192,6 +196,13 @@ def render_template(template_path: str, output_path: str, replacements: Dict[str
     content = Path(template_path).read_text(encoding="utf-8")
     for key, value in replacements.items():
         content = content.replace(f"{{{{{key}}}}}", value)
+
+    # Clean up empty contact-line entries when LinkedIn / GitHub / portfolio
+    # are not provided. Without this the header renders as "email | |" with
+    # dangling separators around empty \href{}{\underline{}} fragments.
+    content = re.sub(r"\\href\{\}\{\\underline\{\}\}\s*\$\|\$\s*", "", content)
+    content = re.sub(r"\s*\$\|\$\s*\\href\{\}\{\\underline\{\}\}", "", content)
+    content = re.sub(r"\\href\{\}\{\\underline\{\}\}", "", content)
 
     # Warn about any remaining unfilled placeholders
     remaining = re.findall(r"\{\{[A-Z_]+\}\}", content)

--- a/.claude/skills/tailor-resume/scripts/profile_extractor.py
+++ b/.claude/skills/tailor-resume/scripts/profile_extractor.py
@@ -282,7 +282,12 @@ def parse_blob(text: str, source: str = "blob") -> Profile:
 
     role_header_re = re.compile(r"(?:company|employer|org(?:anization)?)[:\s]+(.+)", re.IGNORECASE)
     title_re = re.compile(r"(?:title|position|role)[:\s]+(.+)", re.IGNORECASE)
-    date_re = re.compile(r"(?:dates?|period|tenure)[:\s]+(.+?)[\s]*(?:–|-|to)[\s]*(.+)", re.IGNORECASE)
+    # Date separator: dashes, or whitespace-bounded "to" so the substring "to"
+    # inside month names like "October" doesn't get treated as a separator.
+    date_re = re.compile(
+        r"(?:dates?|period|tenure)[:\s]+(.+?)\s*(?:[–—-]|(?<=\s)to(?=\s))\s*(.+)",
+        re.IGNORECASE,
+    )
 
     for line in lines:
         s = line.strip()

--- a/.claude/skills/tailor-resume/templates/resume_template.tex
+++ b/.claude/skills/tailor-resume/templates/resume_template.tex
@@ -1,7 +1,6 @@
 %-------------------------
 % Resume Template — tailor-resume skill
-% Header PII injected at runtime via placeholder tokens (double braces).
-% Body sections show realistic example content — replace with your own.
+% No personal data hardcoded. All double-brace tokens are injected at runtime.
 % Based on: https://github.com/sb2nov/resume  (MIT License)
 %-------------------------
 
@@ -89,8 +88,6 @@
 \begin{document}
 
 %----------HEADING----------
-% Replace {{NAME}}, {{PHONE}}, {{EMAIL}}, {{LINKEDIN_URL}}/{{LINKEDIN_DISPLAY}},
-% {{PORTFOLIO_URL}}/{{PORTFOLIO_DISPLAY}} at runtime — never hardcode PII here.
 \begin{center}
     \textbf{\Huge \scshape {{NAME}}} \\ \vspace{1pt}
     \small {{PHONE}} $|$
@@ -99,93 +96,28 @@
     \href{{{PORTFOLIO_URL}}}{\underline{{{PORTFOLIO_DISPLAY}}}}
 \end{center}
 
+%----------SUMMARY (optional — remove section if empty)----------
+% \section{Summary}
+% {{SUMMARY}}
 
 %-----------EDUCATION-----------
-\section{Education}
-  \resumeSubHeadingListStart
-    \resumeSubheading
-      {University Name}{City, ST}
-      {Degree Program; GPA: X.X/4.0}{Mon. YYYY -- Mon. YYYY}
-    % Add a second entry if applicable:
-    % \resumeSubheading
-    %   {Community College}{City, ST}
-    %   {Associate of Science in Computer Science}{Aug. 2018 -- May 2020}
-  \resumeSubHeadingListEnd
+{{EDUCATION_SECTION}}
 
 
 %-----------EXPERIENCE-----------
-\section{Experience}
-  \resumeSubHeadingListStart
-
-    % Most recent role first
-    \resumeSubheading
-      {Job Title}{Mon. YYYY -- Present}
-      {Company Name}{City, ST}
-      \resumeItemListStart
-        \resumeItem{Accomplished [X] as measured by [Y] by doing [Z] — lead with your strongest impact bullet.}
-        \resumeItem{Reduced [metric] by [X\%] (baseline \textrightarrow{} outcome) by [specific technique or system change].}
-        \resumeItem{Built [system/tool] handling [scale: rows/day, users, TPS] with [reliability/SLA outcome].}
-        \resumeItem{Owned [CI/CD, orchestration, data quality, etc.] end-to-end, cutting [time/cost/incidents] by [X].}
-      \resumeItemListEnd
-
-    \resumeSubheading
-      {Previous Job Title}{Mon. YYYY -- Mon. YYYY}
-      {Previous Company}{City, ST}
-      \resumeItemListStart
-        \resumeItem{Engineered [pipeline/platform/model] achieving [outcome] at [scale] using [tools].}
-        \resumeItem{Migrated [system A] to [system B], improving [latency/cost/reliability] by [metric].}
-        \resumeItem{Collaborated cross-functionally with [teams] to deliver [outcome] within [timeframe].}
-      \resumeItemListEnd
-
-    % Optional: earlier role
-    % \resumeSubheading
-    %   {Earlier Title}{Mon. YYYY -- Mon. YYYY}
-    %   {Earlier Company}{City, Country}
-    %   \resumeItemListStart
-    %     \resumeItem{Built [X] that contributed to [business outcome].}
-    %   \resumeItemListEnd
-
-  \resumeSubHeadingListEnd
+{{EXPERIENCE_SECTION}}
 
 
 %-----------PROJECTS-----------
-\section{Projects}
-    \resumeSubHeadingListStart
-      \resumeProjectHeading
-          {\textbf{Project Name} $|$ \emph{Python, FastAPI, PostgreSQL, Docker}}{YYYY}
-          \resumeItemListStart
-            \resumeItem{Built [what] serving [scale] with [latency/throughput] using [architecture/approach].}
-            \resumeItem{Implemented [observability/CI/testing] reducing [failures/incidents/cost] by [metric].}
-          \resumeItemListEnd
-      \resumeProjectHeading
-          {\textbf{Second Project} $|$ \emph{Spark, Kafka, Airflow, MLflow}}{YYYY}
-          \resumeItemListStart
-            \resumeItem{Designed [architecture decision] for [use case], saving \$[X]/month vs [alternative].}
-            \resumeItem{Achieved [data quality/reliability outcome] by implementing [data contracts/schema enforcement].}
-          \resumeItemListEnd
-    \resumeSubHeadingListEnd
+{{PROJECTS_SECTION}}
 
 
-%-----------CERTIFICATIONS \& PUBLICATIONS-----------
-\section{Certifications \& Publications}
- \begin{itemize}[leftmargin=0.15in, label={}]
-    \small{\item{
-     \textbf{Cert Name}{: Issuing Body $|$}
-     % Add publications with DOI link if applicable:
-     % \textbf{Publication}{: Title -- \href{https://doi.org/xxx}{\underline{DOI}}}
-    }}
- \end{itemize}
+%-----------CERTIFICATIONS-----------
+{{CERTIFICATIONS_SECTION}}
 
 
 %-----------TECHNICAL SKILLS-----------
-\section{Technical Skills}
- \begin{itemize}[leftmargin=0.15in, label={}]
-    \small{\item{
-     \textbf{Languages \& ML}{: Python, SQL, Bash, Pytest, MLflow, Airflow, LangChain, RAG} \\
-     \textbf{Data \& Cloud}{: Spark, Kafka, Databricks, Delta Lake, PostgreSQL, ETL/ELT, Azure, AWS, Docker, Kubernetes} \\
-     \textbf{Tools}{: FastAPI, Streamlit, Elasticsearch, Power BI, DAX, Git, CI/CD, Prometheus, Grafana} \\
-    }}
- \end{itemize}
+{{SKILLS_SECTION}}
 
 %-------------------------------------------
 \end{document}

--- a/tailor_resume/_scripts/latex_renderer.py
+++ b/tailor_resume/_scripts/latex_renderer.py
@@ -106,6 +106,8 @@ def render_skills(skills_data) -> str:
     """
     skills_data: either a list of strings or a dict with categories.
     """
+    if not skills_data:
+        return ""
     if isinstance(skills_data, list):
         # Plain list — output as a single skills line
         skill_str = escape(", ".join(skills_data))
@@ -136,6 +138,8 @@ def render_skills(skills_data) -> str:
 
 
 def render_education(education: List[Dict]) -> str:
+    if not education:
+        return ""
     blocks = ["\\section{Education}", "  \\resumeSubHeadingListStart"]
     for edu in education:
         school = escape(edu.get("school", edu.get("institution", "")))
@@ -172,6 +176,13 @@ def render_template(template_path: str, output_path: str, replacements: Dict[str
     content = Path(template_path).read_text(encoding="utf-8")
     for key, value in replacements.items():
         content = content.replace(f"{{{{{key}}}}}", value)
+
+    # Clean up empty contact-line entries when LinkedIn / GitHub / portfolio
+    # are not provided. Without this the header renders as "email | |" with
+    # dangling separators around empty \href{}{\underline{}} fragments.
+    content = re.sub(r"\\href\{\}\{\\underline\{\}\}\s*\$\|\$\s*", "", content)
+    content = re.sub(r"\s*\$\|\$\s*\\href\{\}\{\\underline\{\}\}", "", content)
+    content = re.sub(r"\\href\{\}\{\\underline\{\}\}", "", content)
 
     # Warn about any remaining unfilled placeholders
     remaining = re.findall(r"\{\{[A-Z_]+\}\}", content)

--- a/tailor_resume/_scripts/profile_extractor.py
+++ b/tailor_resume/_scripts/profile_extractor.py
@@ -281,7 +281,12 @@ def parse_blob(text: str, source: str = "blob") -> Profile:
 
     role_header_re = re.compile(r"(?:company|employer|org(?:anization)?)[:\s]+(.+)", re.IGNORECASE)
     title_re = re.compile(r"(?:title|position|role)[:\s]+(.+)", re.IGNORECASE)
-    date_re = re.compile(r"(?:dates?|period|tenure)[:\s]+(.+?)[\s]*(?:–|-|to)[\s]*(.+)", re.IGNORECASE)
+    # Date separator: dashes, or whitespace-bounded "to" so the substring "to"
+    # inside month names like "October" doesn't get treated as a separator.
+    date_re = re.compile(
+        r"(?:dates?|period|tenure)[:\s]+(.+?)\s*(?:[–—-]|(?<=\s)to(?=\s))\s*(.+)",
+        re.IGNORECASE,
+    )
 
     for line in lines:
         s = line.strip()

--- a/tailor_resume/_templates/resume_template.tex
+++ b/tailor_resume/_templates/resume_template.tex
@@ -1,7 +1,6 @@
 %-------------------------
 % Resume Template — tailor-resume skill
-% Header PII injected at runtime via placeholder tokens (double braces).
-% Body sections show realistic example content — replace with your own.
+% No personal data hardcoded. All double-brace tokens are injected at runtime.
 % Based on: https://github.com/sb2nov/resume  (MIT License)
 %-------------------------
 
@@ -89,8 +88,6 @@
 \begin{document}
 
 %----------HEADING----------
-% Replace {{NAME}}, {{PHONE}}, {{EMAIL}}, {{LINKEDIN_URL}}/{{LINKEDIN_DISPLAY}},
-% {{PORTFOLIO_URL}}/{{PORTFOLIO_DISPLAY}} at runtime — never hardcode PII here.
 \begin{center}
     \textbf{\Huge \scshape {{NAME}}} \\ \vspace{1pt}
     \small {{PHONE}} $|$
@@ -99,93 +96,28 @@
     \href{{{PORTFOLIO_URL}}}{\underline{{{PORTFOLIO_DISPLAY}}}}
 \end{center}
 
+%----------SUMMARY (optional — remove section if empty)----------
+% \section{Summary}
+% {{SUMMARY}}
 
 %-----------EDUCATION-----------
-\section{Education}
-  \resumeSubHeadingListStart
-    \resumeSubheading
-      {University Name}{City, ST}
-      {Degree Program; GPA: X.X/4.0}{Mon. YYYY -- Mon. YYYY}
-    % Add a second entry if applicable:
-    % \resumeSubheading
-    %   {Community College}{City, ST}
-    %   {Associate of Science in Computer Science}{Aug. 2018 -- May 2020}
-  \resumeSubHeadingListEnd
+{{EDUCATION_SECTION}}
 
 
 %-----------EXPERIENCE-----------
-\section{Experience}
-  \resumeSubHeadingListStart
-
-    % Most recent role first
-    \resumeSubheading
-      {Job Title}{Mon. YYYY -- Present}
-      {Company Name}{City, ST}
-      \resumeItemListStart
-        \resumeItem{Accomplished [X] as measured by [Y] by doing [Z] — lead with your strongest impact bullet.}
-        \resumeItem{Reduced [metric] by [X\%] (baseline \textrightarrow{} outcome) by [specific technique or system change].}
-        \resumeItem{Built [system/tool] handling [scale: rows/day, users, TPS] with [reliability/SLA outcome].}
-        \resumeItem{Owned [CI/CD, orchestration, data quality, etc.] end-to-end, cutting [time/cost/incidents] by [X].}
-      \resumeItemListEnd
-
-    \resumeSubheading
-      {Previous Job Title}{Mon. YYYY -- Mon. YYYY}
-      {Previous Company}{City, ST}
-      \resumeItemListStart
-        \resumeItem{Engineered [pipeline/platform/model] achieving [outcome] at [scale] using [tools].}
-        \resumeItem{Migrated [system A] to [system B], improving [latency/cost/reliability] by [metric].}
-        \resumeItem{Collaborated cross-functionally with [teams] to deliver [outcome] within [timeframe].}
-      \resumeItemListEnd
-
-    % Optional: earlier role
-    % \resumeSubheading
-    %   {Earlier Title}{Mon. YYYY -- Mon. YYYY}
-    %   {Earlier Company}{City, Country}
-    %   \resumeItemListStart
-    %     \resumeItem{Built [X] that contributed to [business outcome].}
-    %   \resumeItemListEnd
-
-  \resumeSubHeadingListEnd
+{{EXPERIENCE_SECTION}}
 
 
 %-----------PROJECTS-----------
-\section{Projects}
-    \resumeSubHeadingListStart
-      \resumeProjectHeading
-          {\textbf{Project Name} $|$ \emph{Python, FastAPI, PostgreSQL, Docker}}{YYYY}
-          \resumeItemListStart
-            \resumeItem{Built [what] serving [scale] with [latency/throughput] using [architecture/approach].}
-            \resumeItem{Implemented [observability/CI/testing] reducing [failures/incidents/cost] by [metric].}
-          \resumeItemListEnd
-      \resumeProjectHeading
-          {\textbf{Second Project} $|$ \emph{Spark, Kafka, Airflow, MLflow}}{YYYY}
-          \resumeItemListStart
-            \resumeItem{Designed [architecture decision] for [use case], saving \$[X]/month vs [alternative].}
-            \resumeItem{Achieved [data quality/reliability outcome] by implementing [data contracts/schema enforcement].}
-          \resumeItemListEnd
-    \resumeSubHeadingListEnd
+{{PROJECTS_SECTION}}
 
 
-%-----------CERTIFICATIONS \& PUBLICATIONS-----------
-\section{Certifications \& Publications}
- \begin{itemize}[leftmargin=0.15in, label={}]
-    \small{\item{
-     \textbf{Cert Name}{: Issuing Body $|$}
-     % Add publications with DOI link if applicable:
-     % \textbf{Publication}{: Title -- \href{https://doi.org/xxx}{\underline{DOI}}}
-    }}
- \end{itemize}
+%-----------CERTIFICATIONS-----------
+{{CERTIFICATIONS_SECTION}}
 
 
 %-----------TECHNICAL SKILLS-----------
-\section{Technical Skills}
- \begin{itemize}[leftmargin=0.15in, label={}]
-    \small{\item{
-     \textbf{Languages \& ML}{: Python, SQL, Bash, Pytest, MLflow, Airflow, LangChain, RAG} \\
-     \textbf{Data \& Cloud}{: Spark, Kafka, Databricks, Delta Lake, PostgreSQL, ETL/ELT, Azure, AWS, Docker, Kubernetes} \\
-     \textbf{Tools}{: FastAPI, Streamlit, Elasticsearch, Power BI, DAX, Git, CI/CD, Prometheus, Grafana} \\
-    }}
- \end{itemize}
+{{SKILLS_SECTION}}
 
 %-------------------------------------------
 \end{document}

--- a/tests/test_latex_renderer.py
+++ b/tests/test_latex_renderer.py
@@ -164,11 +164,14 @@ class TestRenderSkills:
         assert "Python" in result
         assert "Airflow" in result
 
-    def test_renders_empty_list(self):
+    def test_returns_empty_string_for_empty_list(self):
+        # An empty skills list should suppress the entire section so the
+        # rendered resume doesn't ship a bare "Technical Skills" header
+        # with no content underneath (which produces a wasted page).
         result = render_skills([])
-        assert "\\section{Technical Skills}" in result
+        assert result == ""
 
-    def test_returns_empty_string_for_invalid_type(self):
+    def test_returns_empty_string_for_none(self):
         result = render_skills(None)
         assert result == ""
 
@@ -197,9 +200,12 @@ class TestRenderEducation:
         result = render_education(edu)
         assert "Ph.D. Computer Science" in result
 
-    def test_empty_education(self):
+    def test_returns_empty_string_for_empty_education(self):
+        # An empty education list should suppress the section entirely so
+        # the resume doesn't render a bare "Education" header with nothing
+        # underneath (which also triggers a "missing \item" LaTeX warning).
         result = render_education([])
-        assert "\\section{Education}" in result
+        assert result == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_profile_extractor.py
+++ b/tests/test_profile_extractor.py
@@ -1006,6 +1006,36 @@ class TestMergeProfiles:
 # ---------------------------------------------------------------------------
 # profile_to_dict
 # ---------------------------------------------------------------------------
+class TestParseBlobDateRegression:
+    def test_october_not_split_on_substring_to(self):
+        """
+        Regression: the blob date regex used `(?:–|-|to)` as the separator,
+        which matched the substring "to" inside month names like "October" —
+        producing start="Oc" and end="ber 2024 – May 2025".
+
+        The fix uses (?<=\\s)to(?=\\s) so "to" only matches when surrounded
+        by whitespace (i.e. when it's a real word, not a substring).
+        """
+        profile = parse_blob(
+            "Company: Acme\nTitle: Engineer\nDates: October 2024 – May 2025\n"
+        )
+        role = profile.experience[0]
+        assert role.start == "October 2024"
+        assert role.end == "May 2025"
+
+    def test_word_to_still_works_as_separator(self):
+        """The word 'to' surrounded by whitespace must still split dates."""
+        profile = parse_blob(
+            "Company: Acme\nTitle: Engineer\nDates: Jan 2022 to Dec 2023\n"
+        )
+        role = profile.experience[0]
+        assert role.start == "Jan 2022"
+        assert role.end == "Dec 2023"
+
+
+# ---------------------------------------------------------------------------
+# profile_to_dict
+# ---------------------------------------------------------------------------
 class TestProfileToDict:
     def test_profile_to_dict_is_serializable(self):
         profile = parse_blob(


### PR DESCRIPTION
Hey — I tried to use this end-to-end (paste a JD, paste a work history blob, get a tailored resume) and ran into four bugs in a row that made the CLI output unusable. This PR fixes all of them. 569 tests pass; the two unrelated failures on this branch are pre-existing on `main`.

## Bug 1 — Template body had no placeholders, renderer body subs were dead code

[`25c149c`](https://github.com/narendranathe/tailor-resume/commit/25c149c) replaced `{{EXPERIENCE_SECTION}}` / `{{EDUCATION_SECTION}}` / etc. with hardcoded example bullets so the `.tex` would compile standalone on GitHub. But `latex_renderer.build_from_profile()` still pushes those keys into the substitution dict — they just no-op silently because the tokens are gone. Every CLI run produces a `.tex` with the user's header injected and the body still showing template example text (`Job Title / Mon. YYYY -- Present / Accomplished [X] as measured by [Y]...`).

This restores the body placeholders so the renderer's substitution actually lands. The example content the template was holding is gone — the renderer owns rendering, the template owns layout. That matches the original design before that commit.

## Bug 2 — Date regex split month names containing the substring \"to\"

`parse_blob`'s `date_re` used `(?:–|-|to)` as the separator alternation. This treats the literal substring `to` as a date delimiter, so:

\`\`\`
Dates: October 2024 – May 2025
\`\`\`

parses as `start=\"Oc\"`, `end=\"ber 2024 – May 2025\"`, and the rendered resume reads `Oc -- ber 2024`. Same for any month name containing `to`.

Fix uses `(?<=\\s)to(?=\\s)` so `to` only matches when whitespace-bounded. Added two regression tests:
- `test_october_not_split_on_substring_to` pins the bug
- `test_word_to_still_works_as_separator` confirms `Jan 2022 to Dec 2023` still parses

## Bug 3 — `render_skills([])` and `render_education([])` produced empty section headers

Both renderers always emit `\\section{Technical Skills}` / `\\section{Education}` even when given an empty list. With a blob that has no skills section, the resulting `.tex` contains a bare \"Technical Skills\" header with nothing under it, which:
- Wastes a page when the rest of the resume just barely fits
- Triggers a `! LaTeX Error: Something's wrong--perhaps a missing \\item.` warning from the empty `\\resumeSubHeadingListStart` / `\\resumeSubHeadingListEnd` pair

`render_projects()` and `render_certifications()` already had the empty guard. This adds it to the other two for consistency. Updated the two existing tests that asserted the header still rendered for empty input — they now assert the section is suppressed entirely, with comments explaining why.

## Bug 4 — Empty LinkedIn / GitHub / portfolio rendered as dangling separators

The header template hardcodes `email | linkedin | portfolio`. When the CLI runs without `--linkedin` and `--portfolio`, the substitution leaves `\\href{}{\\underline{}}` fragments behind and the header reads `user@example.com | |` with two trailing pipes.

`render_template` now post-processes the substituted content with three small regexes that strip empty `\\href{}{\\underline{}}` and the `\$|\$` separators on either side. Existing valid hrefs are untouched.

## Net effect

A fresh `tailor-resume --jd jd.txt --artifact blob.txt:blob` invocation now produces a single-page LaTeX resume with the user's real content, correct dates, no dangling separators, and no empty section headers. Tested end-to-end with `pdflatex` (BasicTeX 2026) — compiles to 1 page, no errors, no warnings.

Happy to split this into 4 separate commits if you'd prefer. They're each independent and could be reviewed/landed separately.