### PR TITLE
ci(coverage): drop omits + raise gate to 84% (closes #75)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,13 @@
 [run]
 # Coverage configuration for the tailor-resume skill.
 #
-# We omit subtrees that are CLI/optional-backend code paths and
-# would need integration tests (real Anthropic API, real Pinecone,
-# real PDF fixtures, etc.) rather than unit tests to exercise.
-# Excluding them keeps the --cov-fail-under gate meaningful for
-# the code we have actually chosen to test.
+# parsers/* and stores/* and claude_vision_extractor.py are now covered by
+# integration tests landed via issue #75. The single remaining omission is
+# parsers/pdf_extractor.py (31% covered), tracked separately by issue #79
+# for the heavier Claude-vision / multi-backend fallback paths.
 #
-# When you wire integration tests for any of these modules, drop
-# them from the omit list and bump --cov-fail-under accordingly.
+# When pdf_extractor.py clears 80%, drop it from omit and bump
+# --cov-fail-under in .github/workflows/ci.yml accordingly.
 
 omit =
-    .claude/skills/tailor-resume/scripts/claude_vision_extractor.py
-    .claude/skills/tailor-resume/scripts/parsers/*
-    .claude/skills/tailor-resume/scripts/stores/*
+    .claude/skills/tailor-resume/scripts/parsers/pdf_extractor.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: python -m pytest tests/ -v
 
       - name: Coverage report
-        run: python -m pytest tests/ --cov=".claude/skills/tailor-resume/scripts" --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=80
+        run: python -m pytest tests/ --cov=".claude/skills/tailor-resume/scripts" --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=84


### PR DESCRIPTION
## Summary
Coordination PR for issue #75 — all three test slices have now landed (#76 parsers, #77 stores, #78 claude_vision_extractor), so this PR updates `.coveragerc` and the CI gate to reflect that work.

## Changes
- **`.coveragerc`** — removed the wildcard omits for `claude_vision_extractor.py`, `stores/*`, and `parsers/*`. Only `parsers/pdf_extractor.py` remains omitted (31% covered; tracked by #79).
- **`.github/workflows/ci.yml`** — bumped `--cov-fail-under` from `80` → `84`.

## Coverage at a glance (with new omit list)

| Module | Cover |
|---|---|
| `claude_vision_extractor.py` | 99% |
| `parsers/__init__.py`, `markdown_parser.py`, `normalizer.py` | 100% |
| `parsers/latex_parser.py` | 92% |
| `parsers/docx_extractor.py` | 97% |
| `parsers/plain_parser.py` | 79% |
| `stores/embeddings.py`, `factory.py`, `pinecone_store.py`, `sqlite_store.py`, `__init__.py` | 100% |
| `stores/base.py` | 87% |
| **TOTAL (omitting `pdf_extractor.py`)** | **84%** |

## Test plan
- [x] `python -m pytest tests/ --cov-config=.coveragerc --cov-fail-under=84` — total 84%, gate passes
- [x] No production code touched
- [ ] CI green on this PR

## Acceptance criteria from #75
- [x] Subtree's coverage ≥ 80% (parsers via slice 1, stores via slice 2, vision via slice 3)
- [x] Subtrees removed from `.coveragerc` `omit` block (pdf_extractor.py held back, tracked by #79)
- [x] `--cov-fail-under` raised commensurately
- [x] Integration tests gated correctly — no live API required by default

Closes #75.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_