### PR TITLE
chore(gitignore): exclude agent worktrees and auto-generated parser fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ htmlcov/
 
 # Local RAG store (SQLite fallback)
 ~/.tailor_resume/
+
+# Claude Code agent worktrees (created by Agent isolation: worktree)
+.claude/worktrees/
+
+# Auto-generated parser test fixtures (created by tests/fixtures/parsers/_make_*.py)
+tests/fixtures/parsers/sample.docx
+tests/fixtures/parsers/sample.pdf


### PR DESCRIPTION
## Summary
Tiny chore — adds two entries to `.gitignore`:

1. **`.claude/worktrees/`** — created at runtime when sub-agents are spawned with `isolation: worktree`. Was showing up as untracked on every session.
2. **`tests/fixtures/parsers/sample.docx`** and **`sample.pdf`** — auto-generated on first test run by `tests/fixtures/parsers/_make_docx.py` / `_make_pdf.py` (the design from PR #76 deliberately keeps these out of the repo).

Stops these from triggering the working-tree-clean stop hook.

## Test plan
- [x] `git status` clean after gitignore update
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_