### PR TITLE
feat: github_ingester ingest_repo + 31 tests (closes #66)

### DIFF
--- a/.claude/skills/tailor-resume/scripts/github_ingester.py
+++ b/.claude/skills/tailor-resume/scripts/github_ingester.py
@@ -25,7 +25,9 @@ Output shape (matches profile_extractor ProjectEntry):
 """
 from __future__ import annotations
 
+import base64
 import json
+import logging
 import os
 import re
 import sys
@@ -33,7 +35,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+_LOG = logging.getLogger(__name__)
 
 _SCRIPTS = Path(__file__).parent
 if str(_SCRIPTS) not in sys.path:
@@ -255,6 +259,245 @@ def inject_github_projects(
     profile["projects"].extend(new_projects)
 
     return profile
+
+
+# ---------------------------------------------------------------------------
+# Issue #66: ingest_repo(url, token) — flat bullet list from a single repo URL
+# ---------------------------------------------------------------------------
+
+_REPO_URL_RE = re.compile(
+    r"^(?:https?://)?(?:www\.)?github\.com/([^/\s]+)/([^/\s]+?)(?:\.git)?/?$",
+    re.IGNORECASE,
+)
+
+
+def _parse_repo_url(url: str) -> Optional[Tuple[str, str]]:
+    """Extract (owner, repo) from a GitHub URL.
+
+    Handles trailing slashes, .git suffix, http/https, and optional www.
+    Returns None for unparseable input.
+    """
+    if not url or not isinstance(url, str):
+        return None
+    m = _REPO_URL_RE.match(url.strip())
+    if not m:
+        return None
+    owner, repo = m.group(1), m.group(2)
+    if not owner or not repo:
+        return None
+    return owner, repo
+
+
+def _ingest_headers(token: Optional[str] = None) -> Dict[str, str]:
+    """Build headers for the ingest_repo API path (separate from module _headers
+    so that the explicit `token` arg always wins over the GITHUB_TOKEN env var).
+    """
+    h = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "tailor-resume/2.0",
+    }
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _api_get(url: str, token: Optional[str] = None) -> Optional[Dict]:
+    """GET a GitHub API URL with the User-Agent + optional Bearer auth.
+
+    Returns parsed JSON or None on any error (HTTP, URL, decode).
+    """
+    req = urllib.request.Request(url, headers=_ingest_headers(token))
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        _LOG.warning("github_ingester: HTTP %s fetching %s", exc.code, url)
+        return None
+    except urllib.error.URLError as exc:
+        _LOG.warning("github_ingester: URL error %s fetching %s", exc.reason, url)
+        return None
+    except Exception as exc:  # pragma: no cover - defensive
+        _LOG.warning("github_ingester: unexpected error fetching %s: %s", url, exc)
+        return None
+
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        _LOG.warning("github_ingester: malformed JSON from %s: %s", url, exc)
+        return None
+
+
+def _fetch_repo_meta(owner: str, repo: str, token: Optional[str] = None) -> Optional[Dict]:
+    return _api_get(f"{_GITHUB_API}/repos/{owner}/{repo}", token)
+
+
+def _fetch_repo_readme(owner: str, repo: str, token: Optional[str] = None) -> str:
+    """Return UTF-8 decoded README content or empty string if absent/error."""
+    data = _api_get(f"{_GITHUB_API}/repos/{owner}/{repo}/readme", token)
+    if not data or not isinstance(data, dict):
+        return ""
+    encoded = data.get("content")
+    if not encoded or not isinstance(encoded, str):
+        return ""
+    try:
+        return base64.b64decode(encoded.replace("\n", "")).decode("utf-8", errors="replace")
+    except (ValueError, TypeError, base64.binascii.Error) as exc:
+        _LOG.warning("github_ingester: failed to decode README: %s", exc)
+        return ""
+
+
+def _bullets_from_readme(readme: str) -> List[str]:
+    """Pull all markdown bullet lines from a README (no cap, no length filter).
+
+    Used as the input to parse_blob — let parse_blob's downstream consumers
+    decide which bullets matter.
+    """
+    out: List[str] = []
+    for raw in readme.splitlines():
+        line = raw.strip()
+        m = re.match(r"^[-*+•]\s+(.+)$", line) or re.match(r"^\d+\.\s+(.+)$", line)
+        if not m:
+            continue
+        text = m.group(1).strip()
+        # Strip surrounding markdown emphasis markers but keep the content.
+        text = re.sub(r"[`*_]+", "", text).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _bullet_to_dict(bullet) -> Dict:
+    """Convert a profile_extractor Bullet dataclass to the issue-spec dict shape."""
+    return {
+        "text": getattr(bullet, "text", ""),
+        "metrics": list(getattr(bullet, "metrics", []) or []),
+        "tools": list(getattr(bullet, "tools", []) or []),
+        "evidence_source": "github",
+        "confidence": "medium",
+    }
+
+
+def _description_bullet(description: str, tools: Optional[List[str]] = None) -> Dict:
+    """Build a fallback bullet from the repo description alone."""
+    try:
+        from text_utils import extract_metrics as _xm, extract_tools as _xt
+        metrics = _xm(description)
+        tool_list = list(tools or []) + _xt(description)
+        # Dedupe while preserving order.
+        seen = set()
+        deduped_tools = []
+        for t in tool_list:
+            if t not in seen:
+                seen.add(t)
+                deduped_tools.append(t)
+        tool_list = deduped_tools
+    except Exception:  # pragma: no cover - defensive
+        metrics = []
+        tool_list = list(tools or [])
+    return {
+        "text": description,
+        "metrics": metrics,
+        "tools": tool_list,
+        "evidence_source": "github",
+        "confidence": "medium",
+    }
+
+
+def ingest_repo(url: str, token: Optional[str] = None) -> List[Dict]:
+    """Fetch README + description for a GitHub repo URL and return project bullets.
+
+    Public repos work without ``token``; supplying a PAT raises the rate limit
+    and (in v3) will permit private repos.
+
+    Returns a list of dicts shaped like::
+
+        {"text": ..., "metrics": [...], "tools": [...],
+         "evidence_source": "github", "confidence": "medium"}
+
+    Behaviour:
+        * Invalid URL → ``[]`` with a logged warning.
+        * No README and no description → ``[]``.
+        * No README but description present → single description-only bullet.
+        * Any HTTP/URL/JSON error → ``[]`` with a logged warning.
+        * Never raises ``urllib`` errors to the caller.
+    """
+    parsed = _parse_repo_url(url)
+    if parsed is None:
+        _LOG.warning("github_ingester: invalid GitHub repo URL: %r", url)
+        return []
+    owner, repo = parsed
+
+    meta = _fetch_repo_meta(owner, repo, token=token)
+    if not isinstance(meta, dict):
+        # Network/HTTP failure already logged in _api_get.
+        return []
+
+    description = (meta.get("description") or "").strip()
+    language = (meta.get("language") or "").strip()
+    topics = meta.get("topics") or []
+    if not isinstance(topics, list):
+        topics = []
+    base_tools: List[str] = []
+    if language:
+        base_tools.append(language)
+    for t in topics:
+        if isinstance(t, str) and t and t not in base_tools:
+            base_tools.append(t)
+
+    readme = _fetch_repo_readme(owner, repo, token=token)
+
+    # Extract bullet candidates from the README and feed them — together with
+    # the description as a synthetic header bullet — through parse_blob using
+    # the repo name as the "company" so the lines get associated with a role.
+    readme_bullets = _bullets_from_readme(readme) if readme else []
+
+    bullets: List[Dict] = []
+
+    if readme_bullets:
+        # Construct a synthetic blob parse_blob can consume.
+        try:
+            from profile_extractor import parse_blob
+            blob_lines = [f"Company: {repo}"]
+            blob_lines.extend(f"- {b}" for b in readme_bullets)
+            profile = parse_blob("\n".join(blob_lines), source="github")
+            for role in profile.experience:
+                for b in role.bullets:
+                    bullets.append(_bullet_to_dict(b))
+        except Exception as exc:  # pragma: no cover - defensive
+            _LOG.warning("github_ingester: parse_blob failed: %s", exc)
+
+    if description:
+        # Prepend the description bullet so it leads the list.
+        bullets.insert(0, _description_bullet(description, tools=base_tools))
+
+    if not bullets:
+        return []
+
+    return bullets
+
+
+def ingest_repo_project(url: str, token: Optional[str] = None) -> Optional[Dict]:
+    """Convenience wrapper that returns a *project entry* dict (with title
+    extracted from the repo name) ready to append to ``profile['projects']``.
+
+    Returns None for invalid URLs or fetch errors. Returns a project dict with
+    an empty ``bullets`` list if the repo has neither description nor README.
+    """
+    parsed = _parse_repo_url(url)
+    if parsed is None:
+        _LOG.warning("github_ingester: invalid GitHub repo URL: %r", url)
+        return None
+    _owner, repo_name = parsed
+    bullets = ingest_repo(url, token=token)
+    return {
+        "name": repo_name,
+        "bullets": bullets,
+        "source": "github",
+        "url": url,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_github_ingester.py
+++ b/tests/test_github_ingester.py
@@ -1,18 +1,25 @@
 """Tests for github_ingester.py — GitHub repo ingestion for resume projects."""
 from __future__ import annotations
 
+import base64
+import json
 import sys
+import urllib.error
 from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "skills" / "tailor-resume" / "scripts"))
 
 from github_ingester import (  # noqa: E402
+    _bullets_from_readme,
     _extract_metrics,
     _extract_readme_bullets,
+    _parse_repo_url,
     _repo_to_project,
     fetch_repo,
     fetch_user_repos,
+    ingest_repo,
+    ingest_repo_project,
     inject_github_projects,
 )
 
@@ -218,3 +225,408 @@ def test_inject_github_projects_creates_projects_key():
         updated = inject_github_projects(profile, "narendranathe")
     assert "projects" in updated
     assert len(updated["projects"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #66: ingest_repo(url, token) — flat bullet list from a single URL
+# ---------------------------------------------------------------------------
+
+
+_README_FOR_INGEST = """\
+# tailor-resume
+
+Some prose paragraph that should be ignored.
+
+## Features
+
+- Reduced application time by 80% using FastAPI for the backend
+- Supports 12 platforms including LinkedIn and Greenhouse exporters
+- Built with Python, Redis, and PostgreSQL for high-throughput ingestion
+
+## Other
+
+1. Numbered item one with FastAPI and metrics 50%
+"""
+
+
+def _b64(s: str) -> str:
+    return base64.b64encode(s.encode("utf-8")).decode("ascii")
+
+
+class _FakeResp:
+    """Minimal context-manager response stub for urllib.request.urlopen."""
+
+    def __init__(self, payload):
+        if isinstance(payload, (dict, list)):
+            self._raw = json.dumps(payload).encode("utf-8")
+        elif isinstance(payload, bytes):
+            self._raw = payload
+        else:
+            self._raw = str(payload).encode("utf-8")
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_urlopen(meta_payload, readme_payload=None, capture=None):
+    """Build a fake urlopen that routes by URL path."""
+
+    def fake_urlopen(req, timeout=15):
+        if capture is not None:
+            capture.setdefault("calls", []).append(
+                {"url": req.full_url, "headers": dict(req.header_items())}
+            )
+        if req.full_url.endswith("/readme"):
+            if readme_payload is None:
+                raise urllib.error.HTTPError(
+                    req.full_url, 404, "Not Found", hdrs=None, fp=None
+                )
+            return _FakeResp(readme_payload)
+        return _FakeResp(meta_payload)
+
+    return fake_urlopen
+
+
+# --- _parse_repo_url ---------------------------------------------------------
+
+
+def test_parse_repo_url_basic():
+    assert _parse_repo_url("https://github.com/narendranathe/tailor-resume") == (
+        "narendranathe",
+        "tailor-resume",
+    )
+
+
+def test_parse_repo_url_trailing_slash():
+    assert _parse_repo_url("https://github.com/narendranathe/tailor-resume/") == (
+        "narendranathe",
+        "tailor-resume",
+    )
+
+
+def test_parse_repo_url_dot_git_suffix():
+    assert _parse_repo_url("https://github.com/narendranathe/tailor-resume.git") == (
+        "narendranathe",
+        "tailor-resume",
+    )
+
+
+def test_parse_repo_url_no_scheme():
+    assert _parse_repo_url("github.com/foo/bar") == ("foo", "bar")
+
+
+def test_parse_repo_url_www():
+    assert _parse_repo_url("https://www.github.com/foo/bar") == ("foo", "bar")
+
+
+def test_parse_repo_url_http_scheme():
+    assert _parse_repo_url("http://github.com/foo/bar") == ("foo", "bar")
+
+
+def test_parse_repo_url_invalid_host():
+    assert _parse_repo_url("https://gitlab.com/foo/bar") is None
+
+
+def test_parse_repo_url_missing_repo():
+    assert _parse_repo_url("https://github.com/foo") is None
+
+
+def test_parse_repo_url_empty():
+    assert _parse_repo_url("") is None
+
+
+def test_parse_repo_url_non_string():
+    assert _parse_repo_url(None) is None  # type: ignore[arg-type]
+
+
+# --- _bullets_from_readme ----------------------------------------------------
+
+
+def test_bullets_from_readme_handles_multiple_markers():
+    text = "- one\n* two\n+ three\n1. four\n"
+    out = _bullets_from_readme(text)
+    assert out == ["one", "two", "three", "four"]
+
+
+def test_bullets_from_readme_strips_emphasis():
+    out = _bullets_from_readme("- **bold** and _italic_ and `code` text")
+    assert out == ["bold and italic and code text"]
+
+
+def test_bullets_from_readme_skips_non_bullets():
+    out = _bullets_from_readme("Just a paragraph.\nAnother line.\n")
+    assert out == []
+
+
+# --- ingest_repo: happy path -------------------------------------------------
+
+
+def test_ingest_repo_happy_path(monkeypatch):
+    meta = {
+        "name": "tailor-resume",
+        "full_name": "narendranathe/tailor-resume",
+        "description": "ATS-optimized resume tailoring tool built with Python.",
+        "language": "Python",
+        "topics": ["fastapi", "resume", "ats"],
+        "default_branch": "main",
+    }
+    readme_payload = {"content": _b64(_README_FOR_INGEST), "encoding": "base64"}
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload)
+    )
+
+    bullets = ingest_repo("https://github.com/narendranathe/tailor-resume")
+    assert isinstance(bullets, list)
+    assert len(bullets) >= 2  # description + at least one README bullet
+    # Description bullet leads
+    assert bullets[0]["text"].startswith("ATS-optimized")
+    assert bullets[0]["evidence_source"] == "github"
+    assert bullets[0]["confidence"] == "medium"
+    # All bullets share the issue-spec shape
+    for b in bullets:
+        assert set(b.keys()) >= {"text", "metrics", "tools", "evidence_source", "confidence"}
+        assert b["evidence_source"] == "github"
+        assert b["confidence"] == "medium"
+    # README bullets came through parse_blob (tools should be detected)
+    texts = [b["text"] for b in bullets]
+    assert any("80%" in t for t in texts)
+
+
+def test_ingest_repo_no_readme_returns_description_only(monkeypatch):
+    meta = {
+        "name": "no-readme-repo",
+        "full_name": "owner/no-readme-repo",
+        "description": "A small CLI tool.",
+        "language": "Python",
+        "topics": [],
+    }
+    # readme_payload=None makes the fake raise 404 for /readme
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=None)
+    )
+
+    bullets = ingest_repo("https://github.com/owner/no-readme-repo")
+    assert len(bullets) == 1
+    assert bullets[0]["text"] == "A small CLI tool."
+    assert bullets[0]["evidence_source"] == "github"
+    assert bullets[0]["confidence"] == "medium"
+    # Tools include the repo language
+    assert "Python" in bullets[0]["tools"]
+
+
+def test_ingest_repo_no_readme_no_description_returns_empty(monkeypatch):
+    meta = {
+        "name": "bare",
+        "full_name": "owner/bare",
+        "description": None,
+        "language": None,
+        "topics": [],
+    }
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=None)
+    )
+
+    assert ingest_repo("https://github.com/owner/bare") == []
+
+
+def test_ingest_repo_invalid_url_returns_empty(caplog):
+    with caplog.at_level("WARNING", logger="github_ingester"):
+        result = ingest_repo("not-a-url")
+    assert result == []
+    assert any("invalid" in rec.message.lower() for rec in caplog.records)
+
+
+def test_ingest_repo_http_error_returns_empty(monkeypatch, caplog):
+    def boom(req, timeout=15):
+        raise urllib.error.HTTPError(req.full_url, 500, "Server Error", hdrs=None, fp=None)
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    with caplog.at_level("WARNING", logger="github_ingester"):
+        result = ingest_repo("https://github.com/foo/bar")
+    assert result == []
+    assert any("HTTP" in rec.message for rec in caplog.records)
+
+
+def test_ingest_repo_url_error_returns_empty(monkeypatch):
+    def boom(req, timeout=15):
+        raise urllib.error.URLError("dns failure")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    assert ingest_repo("https://github.com/foo/bar") == []
+
+
+def test_ingest_repo_malformed_json_returns_empty(monkeypatch):
+    def fake_urlopen(req, timeout=15):
+        return _FakeResp(b"{not-valid-json")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    assert ingest_repo("https://github.com/foo/bar") == []
+
+
+def test_ingest_repo_trailing_slash_parses(monkeypatch):
+    meta = {"name": "r", "full_name": "o/r", "description": "desc", "topics": []}
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=None)
+    )
+    bullets = ingest_repo("https://github.com/o/r/")
+    assert len(bullets) == 1
+    assert bullets[0]["text"] == "desc"
+
+
+def test_ingest_repo_dot_git_parses(monkeypatch):
+    meta = {"name": "r", "full_name": "o/r", "description": "desc", "topics": []}
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=None)
+    )
+    bullets = ingest_repo("https://github.com/o/r.git")
+    assert len(bullets) == 1
+
+
+def test_ingest_repo_token_adds_authorization_header(monkeypatch):
+    meta = {"name": "r", "full_name": "o/r", "description": "desc", "topics": []}
+    capture = {}
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _make_urlopen(meta, readme_payload=None, capture=capture),
+    )
+
+    ingest_repo("https://github.com/o/r", token="ghp_secret123")
+
+    # Headers are normalised to title-case by urllib.
+    auth_values = [
+        v
+        for call in capture["calls"]
+        for k, v in call["headers"].items()
+        if k.lower() == "authorization"
+    ]
+    assert auth_values
+    assert all(v == "Bearer ghp_secret123" for v in auth_values)
+
+
+def test_ingest_repo_user_agent_always_set(monkeypatch):
+    meta = {"name": "r", "full_name": "o/r", "description": "desc", "topics": []}
+    capture = {}
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _make_urlopen(meta, readme_payload=None, capture=capture),
+    )
+
+    ingest_repo("https://github.com/o/r")
+
+    ua_values = [
+        v
+        for call in capture["calls"]
+        for k, v in call["headers"].items()
+        if k.lower() == "user-agent"
+    ]
+    assert ua_values, "Expected User-Agent header on every request"
+    assert all("tailor-resume" in v for v in ua_values)
+
+
+def test_ingest_repo_no_token_omits_authorization(monkeypatch):
+    meta = {"name": "r", "full_name": "o/r", "description": "desc", "topics": []}
+    capture = {}
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _make_urlopen(meta, readme_payload=None, capture=capture),
+    )
+
+    ingest_repo("https://github.com/o/r")
+
+    for call in capture["calls"]:
+        keys = {k.lower() for k in call["headers"].keys()}
+        assert "authorization" not in keys
+
+
+def test_ingest_repo_readme_with_no_bullets_falls_back_to_description(monkeypatch):
+    meta = {
+        "name": "r",
+        "full_name": "o/r",
+        "description": "Plain text repo.",
+        "topics": [],
+    }
+    readme = {"content": _b64("Just a paragraph, no bullets here.\nAnother line.")}
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=readme)
+    )
+    bullets = ingest_repo("https://github.com/o/r")
+    assert len(bullets) == 1
+    assert bullets[0]["text"] == "Plain text repo."
+
+
+def test_ingest_repo_readme_undecodable_base64(monkeypatch):
+    meta = {
+        "name": "r",
+        "full_name": "o/r",
+        "description": "desc here",
+        "topics": [],
+    }
+    readme = {"content": "!!!not-base64!!!"}
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=readme)
+    )
+    bullets = ingest_repo("https://github.com/o/r")
+    # README decode failed silently → still get the description bullet
+    assert len(bullets) == 1
+    assert bullets[0]["text"] == "desc here"
+
+
+def test_ingest_repo_readme_missing_content_key(monkeypatch):
+    meta = {"name": "r", "full_name": "o/r", "description": "desc here", "topics": []}
+    readme = {"encoding": "base64"}  # no content
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=readme)
+    )
+    bullets = ingest_repo("https://github.com/o/r")
+    assert len(bullets) == 1
+    assert bullets[0]["text"] == "desc here"
+
+
+def test_ingest_repo_topics_become_tools_on_description(monkeypatch):
+    meta = {
+        "name": "r",
+        "full_name": "o/r",
+        "description": "A toolkit",
+        "language": "Python",
+        "topics": ["fastapi", "ats"],
+    }
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=None)
+    )
+    bullets = ingest_repo("https://github.com/o/r")
+    assert "Python" in bullets[0]["tools"]
+    assert "fastapi" in bullets[0]["tools"]
+    assert "ats" in bullets[0]["tools"]
+
+
+# --- ingest_repo_project (convenience wrapper) -------------------------------
+
+
+def test_ingest_repo_project_extracts_repo_name(monkeypatch):
+    meta = {
+        "name": "tailor-resume",
+        "full_name": "narendranathe/tailor-resume",
+        "description": "ATS-optimized resume tailoring tool.",
+        "topics": [],
+    }
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _make_urlopen(meta, readme_payload=None)
+    )
+    project = ingest_repo_project("https://github.com/narendranathe/tailor-resume")
+    assert project is not None
+    assert project["name"] == "tailor-resume"
+    assert project["source"] == "github"
+    assert project["url"] == "https://github.com/narendranathe/tailor-resume"
+    assert len(project["bullets"]) == 1
+
+
+def test_ingest_repo_project_invalid_url_returns_none():
+    assert ingest_repo_project("not-a-github-url") is None


### PR DESCRIPTION
## Summary
Closes #66. Adds the `ingest_repo` entry point to `github_ingester.py` and 31 new tests, hitting 83% coverage on the module (above the 80% bar from the issue).

## What landed

### `.claude/skills/tailor-resume/scripts/github_ingester.py`
New public functions per the issue spec:
- **`ingest_repo(url: str, token: Optional[str] = None) -> List[Dict]`** — fetches README + description via the GitHub REST API and returns a list of `{text, metrics, tools, evidence_source: "github", confidence: "medium"}` dicts.
- **`ingest_repo_project(url, token)`** — convenience wrapper returning a `{name, bullets, source, url}` project-entry dict for direct insertion into `profile["projects"]`.

Internal helpers added: `_parse_repo_url`, `_ingest_headers`, `_api_get`, `_fetch_repo_meta`, `_fetch_repo_readme`, `_bullets_from_readme`, `_bullet_to_dict`, `_description_bullet`.

### Design choices
- Pre-existing `fetch_repo` / `fetch_user_repos` / `inject_github_projects` helpers were kept intact (no callers broken); `ingest_repo` is a parallel entry point.
- The explicit `token` arg is authoritative; legacy path still falls back to `os.getenv('GITHUB_TOKEN')`.
- README bullets are extracted via markdown regex, then re-wrapped as a synthetic `Company: {repo}\n- bullet1\n…` blob and fed through `profile_extractor.parse_blob()` so `extract_metrics` / `extract_tools` run uniformly.
- Description-only fallback emits a single bullet with `tools = [language] + topics + extracted_tools`. If both description and README exist, the description leads.
- All bullets emitted by `ingest_repo` carry `evidence_source="github"` and `confidence="medium"` per the acceptance criteria.

### Tests
- 52 total in `tests/test_github_ingester.py` (21 pre-existing + 31 new).
- Mocks `urllib.request.urlopen` so no real network calls.
- Covers: happy path, no README (description-only), invalid URL, trailing-slash + `.git` suffix handling, HTTP error → empty list, `token` parameter inserts `Authorization: Bearer …` header, `User-Agent` always set.

## Acceptance criteria from #66
- [x] `ingest_repo(url, token)` returns spec'd dict shape
- [x] Repos with no README handled (description-only / empty)
- [x] Repo name extracted as project title (`ingest_repo_project`)
- [x] Extracted text passes through `profile_extractor.parse_blob()`
- [x] Test coverage ≥ 80% (actual: 83%)
- [x] `ruff check` clean

## Test plan
- [x] `pytest tests/test_github_ingester.py -v` → 52 passed
- [x] `pytest --cov=github_ingester` → 83%
- [x] `ruff check` clean
- [ ] CI green

Closes #66.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_