### PR TITLE
test(vault-client): raise coverage 77% → 99% + token-redaction assertions (closes #65)

### DIFF
--- a/tests/test_vault_client.py
+++ b/tests/test_vault_client.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import base64
+import io
+import json
 import sys
+import urllib.error
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,7 +13,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "skills" / "ta
 
 from vault_client import (  # noqa: E402
     VaultEntry,
+    _api,
     _branch_name,
+    _ensure_branch,
+    _file_sha,
     delete_branch,
     get_version,
     list_versions,
@@ -207,3 +213,261 @@ def test_branch_name_strips_whitespace():
 
 def test_branch_name_empty_uses_anonymous():
     assert _branch_name("") == "vault/anonymous"
+
+
+# ---------------------------------------------------------------------------
+# _api — exercises urllib.request.urlopen wrapper, error paths, token redaction
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    """Minimal context-manager response stub for urllib.request.urlopen."""
+
+    def __init__(self, payload):
+        if isinstance(payload, (dict, list)):
+            self._raw = json.dumps(payload).encode("utf-8")
+        elif isinstance(payload, bytes):
+            self._raw = payload
+        else:
+            self._raw = str(payload).encode("utf-8")
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_api_no_token_returns_none(monkeypatch):
+    monkeypatch.delenv("GITHUB_VAULT_TOKEN", raising=False)
+    assert _api("/git/ref/heads/main") is None
+
+
+def test_api_success_returns_parsed_json(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=15):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["data"] = req.data
+        return _FakeResp({"ok": True})
+
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", "ghp_secret_value_XYZ")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    result = _api("/git/ref/heads/main")
+    assert result == {"ok": True}
+    assert captured["url"].endswith("/repos/narendranathe/resume-vault/git/ref/heads/main")
+    assert captured["method"] == "GET"
+    auth = {k.lower(): v for k, v in captured["headers"].items()}.get("authorization")
+    assert auth == "Bearer ghp_secret_value_XYZ"
+
+
+def test_api_empty_body_returns_empty_dict(monkeypatch):
+    def fake_urlopen(req, timeout=15):
+        return _FakeResp(b"")
+
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", "tok")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    assert _api("/whatever", method="DELETE") == {}
+
+
+def test_api_post_serializes_json_body(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=15):
+        captured["data"] = req.data
+        captured["method"] = req.get_method()
+        return _FakeResp({"created": True})
+
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", "tok")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    body = {"ref": "refs/heads/vault/x", "sha": "abc"}
+    _api("/git/refs", method="POST", body=body)
+    assert captured["method"] == "POST"
+    assert json.loads(captured["data"].decode()) == body
+
+
+def test_api_http_error_returns_none_and_does_not_log_token(monkeypatch, capsys):
+    def boom(req, timeout=15):
+        raise urllib.error.HTTPError(
+            req.full_url, 422, "Unprocessable", hdrs=None, fp=io.BytesIO(b"error body")
+        )
+
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", "ghp_super_secret_TOKEN_VALUE")
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+
+    assert _api("/git/refs", method="POST", body={"ref": "x"}) is None
+    captured = capsys.readouterr()
+    assert "ghp_super_secret_TOKEN_VALUE" not in captured.out
+    assert "ghp_super_secret_TOKEN_VALUE" not in captured.err
+    assert "422" in captured.out
+
+
+def test_api_http_error_no_fp_handles_gracefully(monkeypatch):
+    def boom(req, timeout=15):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", "tok")
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    assert _api("/contents/missing.tex") is None
+
+
+def test_api_url_error_returns_none_and_does_not_log_token(monkeypatch, capsys):
+    def boom(req, timeout=15):
+        raise urllib.error.URLError("dns failure")
+
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", "ghp_another_secret_TOKEN")
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    assert _api("/git/ref/heads/main") is None
+    captured = capsys.readouterr()
+    assert "ghp_another_secret_TOKEN" not in captured.out
+    assert "ghp_another_secret_TOKEN" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _ensure_branch — failure path when neither main nor master exist
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_branch_returns_false_when_no_base_branch(capsys):
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api") as mock_api:
+            mock_api.side_effect = [None, None, None]
+            assert _ensure_branch("ghost") is False
+    out = capsys.readouterr().out
+    assert "Cannot find main/master" in out
+
+
+def test_push_version_returns_none_when_ensure_branch_fails():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api") as mock_api:
+            mock_api.side_effect = [None, None, None]
+            entry = push_version("u9", "Acme", "DE", _TEX, _META)
+    assert entry is None
+
+
+# ---------------------------------------------------------------------------
+# _file_sha — covers update path (existing file)
+# ---------------------------------------------------------------------------
+
+
+def test_file_sha_returns_sha_when_present():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value={"sha": "blob123"}):
+            assert _file_sha("Acme_DE_20240101_000000.tex", "vault/u1") == "blob123"
+
+
+def test_file_sha_returns_none_when_absent():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value=None):
+            assert _file_sha("missing.tex", "vault/u1") is None
+
+
+def test_push_version_updates_existing_files():
+    """When .tex / .meta.json already exist, _file_sha returns a sha that gets
+    threaded into the PUT body (update mode)."""
+    branch_ref = {"object": {"sha": "deadbeef"}}
+    tex_commit = {"commit": {"sha": "newcommit"}}
+    meta_commit = {"commit": {"sha": "newmeta"}}
+
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api") as mock_api:
+            mock_api.side_effect = [
+                branch_ref,                # branch exists
+                {"sha": "tex_blob_sha"},   # _file_sha .tex → existing
+                tex_commit,                # PUT .tex
+                {"sha": "meta_blob_sha"},  # _file_sha .meta → existing
+                meta_commit,               # PUT .meta
+            ]
+            entry = push_version("u_update", "Acme", "DE", _TEX, _META)
+
+    assert entry is not None
+    put_calls = [c for c in mock_api.call_args_list if c.kwargs.get("method") == "PUT"]
+    assert len(put_calls) == 2
+    for call in put_calls:
+        assert "sha" in call.kwargs["body"]
+
+
+def test_push_version_commit_sha_empty_on_put_failure():
+    """If the .tex PUT returns None (HTTP 500), commit_sha is empty but no crash."""
+    branch_ref = {"object": {"sha": "deadbeef"}}
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api") as mock_api:
+            mock_api.side_effect = [
+                branch_ref,   # branch exists
+                None,         # _file_sha .tex → not found
+                None,         # PUT .tex → HTTP 500 / failure
+                None,         # _file_sha .meta → not found
+                None,         # PUT .meta → also fails
+            ]
+            entry = push_version("u_fail", "Acme", "DE", _TEX, _META)
+    assert entry is not None
+    assert entry.commit_sha == ""
+
+
+# ---------------------------------------------------------------------------
+# list_versions — error / empty paths
+# ---------------------------------------------------------------------------
+
+
+def test_list_versions_tree_fetch_error_returns_empty():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value=None):
+            assert list_versions("user_missing") == []
+
+
+def test_list_versions_empty_tree_returns_empty():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value={"tree": []}):
+            assert list_versions("user_empty") == []
+
+
+# ---------------------------------------------------------------------------
+# get_version — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_version_missing_file_returns_none():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value=None):
+            assert get_version("user1", "missing_file") is None
+
+
+def test_get_version_response_without_content_returns_none():
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value={"sha": "x"}):
+            assert get_version("user1", "broken") is None
+
+
+def test_get_version_undecodable_content_returns_none():
+    """Bad base64 → base64.b64decode raises; we return None."""
+    with patch.dict("os.environ", {"GITHUB_VAULT_TOKEN": "tok"}):
+        with patch("vault_client._api", return_value={"content": "!!!not-base64!!!"}):
+            assert get_version("user1", "weird") is None
+
+
+# ---------------------------------------------------------------------------
+# Token redaction — sweep public surface for log leaks
+# ---------------------------------------------------------------------------
+
+
+def test_push_version_does_not_log_token_on_failure(monkeypatch, capsys):
+    """Even when everything fails, the token value never appears in stdout/stderr."""
+    secret = "ghp_LEAK_CHECK_TOKEN_98765"
+    monkeypatch.setenv("GITHUB_VAULT_TOKEN", secret)
+
+    def boom(req, timeout=15):
+        raise urllib.error.HTTPError(req.full_url, 500, "Boom", hdrs=None, fp=None)
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    result = push_version("u", "Co", "R", _TEX, _META)
+    assert result is None
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err


### PR DESCRIPTION
## Summary
Lifts `vault_client.py` test coverage from **77% → 99%**. The module was shipped in commit `743ad71` (#65/#66/#68) with only 14 tests covering 77% — **below the 86% CI gate**. This adds 19 targeted tests, bringing total project coverage to **87.53%** (gate 86%).

## What's tested (new)
- `_api` wrapper: success, empty body, POST body JSON serialization, `HTTPError` (with and without `fp`), `URLError`, no-token short-circuit
- `_ensure_branch` failure when neither `main` nor `master` ref exists → `push_version` returns `None`
- `_file_sha` returning a sha (update path) → PUT body carries `sha` field
- `list_versions` empty-tree and fetch-error paths
- `get_version` missing-content, no-content-key, undecodable-base64 paths
- **Token-redaction assertions** on `_api` HTTPError, `_api` URLError, and `push_version` failure — uses a unique sentinel token (`ghp_LEAK_CHECK_TOKEN_98765`) and asserts it never appears in captured stdout/stderr

## Coverage delta
- `vault_client.py`: **77% → 99%** (146 stmts, 1 miss — only the `sys.path` bootstrap on line 37)
- Total project: now **87.53%** (gate 86%) — passes
- 33/33 vault tests pass

## Design notes confirmed
- **SHA-256 dedup explicitly skipped** per owner decision. The shipped module computes `content_hash` and stores it in `.meta.json`, but does NOT perform a "skip push if identical" round-trip — pushes always proceed, UTC timestamp keeps filenames unique. Tests verify this behavior.
- Stdlib only — no `requests`/`httpx`.
- Token never logged — explicitly asserted in tests.

## Diff
```
tests/test_vault_client.py | 264 +++++++++++++++++++++++++++++++++++++++++++++
1 file changed, 264 insertions(+)
```

No production code touched.

Closes #65 (verifies acceptance criteria of the shipped module).

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_