### PR TITLE
fix(pipeline): unwrap CoverLetterResult.tex before write_text (closes #87)

### DIFF
--- a/.claude/skills/tailor-resume/scripts/pipeline.py
+++ b/.claude/skills/tailor-resume/scripts/pipeline.py
@@ -115,9 +115,10 @@ def execute(config: TailorConfig) -> TailorResult:
     cover_letter_path: Optional[str] = None
     if config.cover_letter:
         from cover_letter_renderer import build_cover_letter  # noqa: E402
-        cover_letter_tex = build_cover_letter(
+        cover_letter_result = build_cover_letter(
             profile_dict, report, config.header, jd_text=config.jd_text
         )
+        cover_letter_tex = cover_letter_result.tex
         cover_letter_path = str(Path(config.output_path).parent / "cover_letter.tex")
         Path(cover_letter_path).write_text(cover_letter_tex, encoding="utf-8")
 
@@ -174,9 +175,10 @@ def execute_text(
     cover_letter_path: Optional[str] = None
     if cover_letter:
         from cover_letter_renderer import build_cover_letter  # noqa: E402
-        cover_letter_tex = build_cover_letter(
+        cover_letter_result = build_cover_letter(
             profile_dict, report, header or {}, jd_text=jd_text
         )
+        cover_letter_tex = cover_letter_result.tex
         cover_letter_path = str(Path(output_path).parent / "cover_letter.tex")
         Path(cover_letter_path).write_text(cover_letter_tex, encoding="utf-8")
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -90,6 +90,53 @@ class TestExecuteText:
         assert result.cover_letter_tex is None
         assert result.cover_letter_path is None
 
+    def test_cover_letter_true_writes_tex_file(self, tmp_path, monkeypatch):
+        """
+        Regression for the bug fixed in issue #87.
+
+        Before the fix, pipeline wrote the entire `CoverLetterResult` dataclass
+        to disk instead of its `.tex` attribute, raising `TypeError` at runtime.
+        This test pins the contract: `execute_text(..., cover_letter=True)`
+        must produce a real .tex file on disk containing the rendered cover
+        letter, and `result.cover_letter_tex` must be the same string.
+        """
+        from pathlib import Path
+
+        import cover_letter_renderer
+
+        # Stub out the renderer so the test doesn't depend on Claude/Anthropic
+        # or the template internals — it's the call-site contract under test.
+        sentinel_tex = (
+            "\\documentclass{article}\n\\begin{document}\n"
+            "PARA ONE.\n\nPARA TWO.\n\\end{document}\n"
+        )
+
+        def fake_build_cover_letter(profile_dict, report, header, jd_text, method="claude"):
+            return cover_letter_renderer.CoverLetterResult(
+                tex=sentinel_tex,
+                txt="PARA ONE.\n\nPARA TWO.\n",
+                docx_path=None,
+                method_used="template",
+                word_count=4,
+            )
+
+        monkeypatch.setattr(
+            cover_letter_renderer, "build_cover_letter", fake_build_cover_letter
+        )
+
+        from pipeline import execute_text
+        result = execute_text(
+            JD_TEXT,
+            BLOB_TEXT,
+            output_path=str(tmp_path / "r.tex"),
+            cover_letter=True,
+        )
+
+        assert result.cover_letter_tex == sentinel_tex
+        assert result.cover_letter_path is not None
+        on_disk = Path(result.cover_letter_path).read_text(encoding="utf-8")
+        assert on_disk == sentinel_tex
+
 
 # ---------------------------------------------------------------------------
 # TailorConfig / TailorResult data classes


### PR DESCRIPTION
## Bug
Both `pipeline.execute()` (line 118) and `pipeline.execute_text()` (line 177) called `cover_letter_renderer.build_cover_letter()` and passed its return value directly to `Path.write_text()`, but `build_cover_letter` returns a `CoverLetterResult` dataclass — not a string. Any user enabling `cover_letter=True` hit a `TypeError` at runtime.

## Fix
Two-line change at each call site: unwrap `result.tex` before writing.

```diff
-        cover_letter_tex = build_cover_letter(
+        cover_letter_result = build_cover_letter(
             profile_dict, report, config.header, jd_text=config.jd_text
         )
+        cover_letter_tex = cover_letter_result.tex
         cover_letter_path = str(Path(config.output_path).parent / "cover_letter.tex")
         Path(cover_letter_path).write_text(cover_letter_tex, encoding="utf-8")
```

## Regression test
Added `test_cover_letter_true_writes_tex_file` to `tests/test_pipeline.py`. Mocks `cover_letter_renderer.build_cover_letter` to return a `CoverLetterResult` with a sentinel `.tex` string, then asserts:
1. `result.cover_letter_tex` equals the sentinel
2. `result.cover_letter_path` is set
3. The on-disk file content equals the sentinel

If anyone re-introduces the bug, this test fails fast.

## Test plan
- [x] 17/17 `test_pipeline.py` tests pass locally (12 existing + 1 new across both classes, with the existing `test_cover_letter_false_by_default` still green)
- [x] Ruff clean
- [ ] CI green

Closes #87.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_