### PR TITLE
feat(ats_scorer): add get_scorer factory + embedding→formula fallback (closes #86)

### DIFF
--- a/.claude/skills/tailor-resume/scripts/ats_scorer.py
+++ b/.claude/skills/tailor-resume/scripts/ats_scorer.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import math
 import sys
 from pathlib import Path
-from typing import Tuple
+from typing import Callable, Tuple
 
 _SCRIPTS = Path(__file__).parent
 if str(_SCRIPTS) not in sys.path:
@@ -36,6 +36,25 @@ def _cosine(a: list, b: list) -> float:
     return dot / (na * nb)
 
 
+def get_scorer(method: str) -> Callable[[str, str], ATSScoreResult]:
+    """
+    Factory: return the scoring function for `method`.
+
+    Mirrors the `rag_store.get_store()` pattern so callers can hold a
+    reference to a specific engine without re-dispatching on every call.
+
+    Raises ValueError for unknown methods.
+    """
+    method = method.lower().strip()
+    if method == "formula":
+        return _score_formula
+    if method == "embedding":
+        return _score_embedding
+    if method == "claude":
+        return _score_claude
+    raise ValueError(f"Unknown method '{method}'. Use: formula | embedding | claude")
+
+
 def score(jd: str, resume: str, method: str = "formula") -> ATSScoreResult:
     """
     Score resume alignment against a JD using the specified engine.
@@ -50,20 +69,8 @@ def score(jd: str, resume: str, method: str = "formula") -> ATSScoreResult:
 
     Raises:
         ValueError: for unknown method values.
-        NotImplementedError: for method="claude" until Issue #63 is implemented.
     """
-    method = method.lower().strip()
-
-    if method == "formula":
-        return _score_formula(jd, resume)
-
-    if method == "embedding":
-        return _score_embedding(jd, resume)
-
-    if method == "claude":
-        return _score_claude(jd, resume)
-
-    raise ValueError(f"Unknown method '{method}'. Use: formula | embedding | claude")
+    return get_scorer(method)(jd, resume)
 
 
 def _score_formula(jd: str, resume: str) -> ATSScoreResult:
@@ -89,12 +96,39 @@ def _score_embedding(jd: str, resume: str) -> ATSScoreResult:
     Option A: Cosine similarity between JD and resume embeddings.
     Uses OpenAI text-embedding-3-small if OPENAI_API_KEY is set,
     otherwise falls back to TF-IDF character n-gram hashing (dim=128).
+
+    Falls all the way back to the formula scorer if `embed()` raises or
+    returns an empty vector — in that case `method_used` is set to
+    `"embedding (formula fallback)"` so callers can tell the difference.
     """
     # Lazy import — avoids side effects at module load; rag_store may print warnings
     from rag_store import embed  # noqa: E402
 
-    jd_vec = embed(jd)
-    resume_vec = embed(resume)
+    try:
+        jd_vec = embed(jd)
+        resume_vec = embed(resume)
+    except Exception:
+        fallback = _score_formula(jd, resume)
+        return ATSScoreResult(
+            score=fallback.score,
+            reasoning=f"{fallback.reasoning} [embed() raised; used formula]",
+            bullet_scores=[],
+            recommendations=fallback.recommendations,
+            method_used="embedding (formula fallback)",
+            formula_score=fallback.score,
+        )
+
+    if not jd_vec or not resume_vec:
+        fallback = _score_formula(jd, resume)
+        return ATSScoreResult(
+            score=fallback.score,
+            reasoning=f"{fallback.reasoning} [embed() returned empty; used formula]",
+            bullet_scores=[],
+            recommendations=fallback.recommendations,
+            method_used="embedding (formula fallback)",
+            formula_score=fallback.score,
+        )
+
     similarity = _cosine(jd_vec, resume_vec)
     embedding_score = max(0, min(100, int(similarity * 100)))
 

--- a/tests/test_ats_scorer.py
+++ b/tests/test_ats_scorer.py
@@ -156,3 +156,81 @@ def test_method_case_insensitive():
     from ats_scorer import score
     result = score(JD, RESUME, method="FORMULA")
     assert result.method_used == "formula"
+
+
+# ---------------------------------------------------------------------------
+# Issue #86 — get_scorer factory + embedding fallback to formula on hard failure
+# ---------------------------------------------------------------------------
+class TestGetScorerFactory:
+    def test_factory_returns_formula_callable(self):
+        from ats_scorer import _score_formula, get_scorer
+        assert get_scorer("formula") is _score_formula
+
+    def test_factory_returns_embedding_callable(self):
+        from ats_scorer import _score_embedding, get_scorer
+        assert get_scorer("embedding") is _score_embedding
+
+    def test_factory_returns_claude_callable(self):
+        from ats_scorer import _score_claude, get_scorer
+        assert get_scorer("claude") is _score_claude
+
+    def test_factory_case_insensitive(self):
+        from ats_scorer import _score_formula, get_scorer
+        assert get_scorer("FORMULA") is _score_formula
+        assert get_scorer(" Embedding ") is __import__("ats_scorer")._score_embedding
+
+    def test_factory_unknown_method_raises(self):
+        from ats_scorer import get_scorer
+        with pytest.raises(ValueError, match="Unknown method"):
+            get_scorer("bogus")
+
+    def test_factory_callable_returns_ats_score_result(self):
+        from ats_scorer import get_scorer
+        scorer = get_scorer("formula")
+        result = scorer(JD, RESUME)
+        assert isinstance(result, ATSScoreResult)
+
+
+class TestEmbeddingFallbackToFormula:
+    """Issue #86: _score_embedding must fall back to formula on hard failure."""
+
+    def test_embed_raising_triggers_formula_fallback(self):
+        from ats_scorer import score
+
+        def boom(_text):
+            raise RuntimeError("simulated embed backend down")
+
+        with patch("rag_store.embed", side_effect=boom):
+            result = score(JD, RESUME, method="embedding")
+
+        assert isinstance(result, ATSScoreResult)
+        assert result.method_used == "embedding (formula fallback)"
+        assert 0 <= result.score <= 100
+        # Reasoning should explain why the fallback happened
+        assert "embed() raised" in result.reasoning
+        # Formula score is set to mirror the actual score on this path
+        assert result.formula_score == result.score
+
+    def test_empty_embed_triggers_formula_fallback(self):
+        from ats_scorer import score
+        with patch("rag_store.embed", return_value=[]):
+            result = score(JD, RESUME, method="embedding")
+        assert result.method_used == "embedding (formula fallback)"
+        assert "returned empty" in result.reasoning
+
+    def test_fallback_recommendations_come_from_formula(self):
+        """Fallback path must still surface recommendations so the UI stays useful."""
+        from ats_scorer import score
+        with patch("rag_store.embed", side_effect=RuntimeError("nope")):
+            result = score(JD, RESUME, method="embedding")
+        assert isinstance(result.recommendations, list)
+        # Formula always produces at least one recommendation against a non-trivial JD/resume
+        assert len(result.recommendations) > 0
+
+    def test_normal_embedding_path_unchanged(self):
+        """Sanity: a successful embed still returns 'embedding' method_used."""
+        from ats_scorer import score
+        with patch("rag_store.embed", return_value=[0.5] * 256):
+            result = score(JD, RESUME, method="embedding")
+        assert result.method_used == "embedding"
+        assert "fallback" not in result.method_used


### PR DESCRIPTION
## Summary
Closes two gaps from #62 that were carried into the follow-up issue #86:

1. **No `get_scorer(method)` factory** — score dispatch was inline `if`-else. Now mirrors `rag_store.get_store()`: `get_scorer("formula" | "embedding" | "claude") -> Callable[[str, str], ATSScoreResult]`. `score()` delegates to it, so there's one source of truth for the method→scorer mapping. Useful for callers holding a reference to a specific engine.

2. **`_score_embedding` had no hard-failure fallback** — when `rag_store.embed()` raised or returned an empty list, the cosine math silently produced a `0` score. Now both cases fall back to `_score_formula` and set `method_used = "embedding (formula fallback)"` so the caller can detect it. The TF-IDF middle layer is preserved (no `OPENAI_API_KEY` still works via `rag_store`'s existing TF-IDF fallback — `method_used = "embedding (tfidf fallback)"`).

## Behavior matrix

| Scenario | `method_used` |
|---|---|
| `embed()` returns 1536-dim (OpenAI succeeds) | `"embedding"` |
| `embed()` returns 128-dim (TF-IDF fallback, no OPENAI key) | `"embedding (tfidf fallback)"` |
| `embed()` raises | `"embedding (formula fallback)"` |
| `embed()` returns `[]` | `"embedding (formula fallback)"` |

## Tests added (10)
- `TestGetScorerFactory` — 6 tests for the factory: returns each callable, case-insensitive, raises on unknown method
- `TestEmbeddingFallbackToFormula` — 4 tests: embed-raising → fallback, embed-empty → fallback, fallback recommendations come from formula, normal path unchanged

## Coverage delta
- `ats_scorer.py`: **98% → 99%** (only `sys.path.insert` bootstrap remains uncovered)
- 25/25 tests pass (15 existing + 10 new)
- Ruff clean

Closes #86.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_