### PR TITLE
chore: bump version to 0.1.1 for next PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tailor-resume"
-version = "0.1.0"
+version = "0.1.1"
 description = "ATS-optimized, recruiter-ready resume tailoring from the command line"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Why
The existing `v0.1.0` tag on this repo points to an older commit (`7f015a2`), before all the Wave 1-4 work and the v2 MVP additions landed. PyPI is immutable — `tailor-resume==0.1.0` there cannot be replaced — so this bump unlocks publishing the current `main` (which now includes `api_server`, `ats_scorer`, `cover_letter_renderer`, `vault_client`, `github_ingester`, expanded test coverage, etc.) as `v0.1.1`.

## What
One-line change: `pyproject.toml` `version = "0.1.0"` → `version = "0.1.1"`.

## After merge
```bash
git checkout main && git pull
git tag v0.1.1
git push origin v0.1.1
```
That triggers `publish-pypi.yml`, which builds from current `main` and uploads to PyPI via the trusted publisher you already configured.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_