### PR TITLE
fix(dockerfile): healthcheck targeted nonexistent /health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,12 @@ COPY .claude/skills/tailor-resume/scripts/ ./.claude/skills/tailor-resume/script
 COPY .claude/skills/tailor-resume/templates/ ./.claude/skills/tailor-resume/templates/
 
 EXPOSE 8080
-HEALTHCHECK --interval=30s --timeout=5s CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+# Healthcheck: verify the MCP server is bound and accepting connections.
+# Uses a plain TCP connect instead of an HTTP request because the
+# streamable-http MCP transport at /mcp may respond with non-2xx codes to
+# bare GET requests (it expects session-aware POST/SSE clients). On Fly.io
+# the platform-level healthcheck in fly.toml is what actually gates traffic.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD python -c "import socket; s=socket.socket(); s.settimeout(3); s.connect(('localhost', 8080)); s.close()" || exit 1
 
 CMD ["python", "server.py"]


### PR DESCRIPTION
## Bug
The Dockerfile `HEALTHCHECK` directive probed `http://localhost:8080/health`, but **that endpoint has never existed**. `server.py` (the MCP server entrypoint) only exposes `/mcp` via FastMCP's streamable-http transport. So the container's Docker-level healthcheck was guaranteed to fail every check interval.

The bug was masked on Fly.io because Fly uses the platform-level check in `fly.toml` (`GET /mcp`), not the Docker `HEALTHCHECK`. But it's still wrong, and anyone running the image outside Fly (plain `docker run`) sees the container flagged as unhealthy.

## Fix
Replace the broken `urlopen('/health')` with a TCP-connect probe to port 8080. Verifies the process is bound and accepting connections without depending on the MCP protocol's HTTP semantics — streamable-http expects session-aware POST/SSE clients, so a bare GET could return 4xx codes that would falsely fail the check.

```diff
-HEALTHCHECK --interval=30s --timeout=5s CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD python -c "import socket; s=socket.socket(); s.settimeout(3); s.connect(('localhost', 8080)); s.close()" || exit 1
```

Also adds `--start-period=10s` so the first 10 seconds after container start don't count failures against the threshold — gives FastMCP time to import scripts and bind the port.

## Why TCP-connect (not HTTP GET)
- Docker-level check just needs to answer "is the process alive?"
- Platform-level check in `fly.toml` (`method = "GET"` `path = "/mcp"`) handles the deep protocol check
- TCP-connect is robust to MCP transport changes (e.g. path change from `/mcp` to `/messages` in a future MCP version)

## Test plan
- [x] Diff is 7 added / 1 removed lines, Dockerfile only
- [x] No production code touched
- [ ] CI green
- [ ] Validated end-to-end after `FLY_API_TOKEN` is added and a deploy runs (separate task — issue #56)

Discovered during the deploy-readiness audit for #56.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_