### PR TITLE
feat(setup): first-run onboarding wizard — PRD + impl + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ htmlcov/
 *.swp
 *.swo
 
+# Node — frontend deps and build output never go in git
+node_modules/
+web_app/frontend/dist/
+package-lock.json
+
 # macOS
 .DS_Store
 

--- a/migrations/003_user_setup.sql
+++ b/migrations/003_user_setup.sql
@@ -1,0 +1,19 @@
+-- migrations/003_user_setup.sql
+-- First-run setup wizard state — Epic #91 (M1).
+-- Run in Supabase SQL editor or via psql.
+-- Idempotent: safe to apply on databases where some columns already exist.
+
+ALTER TABLE user_profiles
+    ADD COLUMN IF NOT EXISTS target_roles JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS target_companies JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS setup_completed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS setup_skipped_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS setup_progress_step TEXT NOT NULL DEFAULT 'welcome';
+
+-- Existing RLS policies from 001_user_profiles.sql apply at the row level
+-- (auth.uid()::text = user_id) and cover all columns on the row.
+-- No new policies needed.
+
+-- Index supports the "skipped vs completed" route guard query:
+CREATE INDEX IF NOT EXISTS idx_user_profiles_setup_state
+    ON user_profiles (setup_completed_at, setup_skipped_at);

--- a/specs/prd_login_setup.md
+++ b/specs/prd_login_setup.md
@@ -1,0 +1,310 @@
+# PRD: Login + First-Run Setup Wizard
+
+> Product-Driven Development pipeline: **Problem → Users → Stories → Flow → Modules → Acceptance → Metrics**.
+> All architectural decisions made here will be appended to `specs/README.md` upon implementation.
+
+---
+
+## Overview
+
+The current web app (`web_app/frontend/src/App.jsx`) drops a freshly signed-in user straight onto the tailoring form (`TailorForm.jsx`) with no orientation, no stored profile, and no target context. Every tailor run starts from a blank slate — the user must re-paste a JD, re-upload a resume, and re-type contact info on every visit.
+
+This PRD specifies a **first-run setup wizard** that runs once after sign-up. It collects the three pieces of state that unlock fast subsequent runs:
+
+1. **Target Roles** — what jobs the user is applying for (drives JD-matching heuristics and Signal Category weighting).
+2. **Target Companies** — a tracked watchlist (drives vault organisation, future job-board ingestion, and analytics).
+3. **Resume Vault** — the base Profile uploaded once and reused across every tailor run.
+
+The wizard is gated on a `setup_completed_at` flag in `user_profiles`. Returning users skip it. Users who quit mid-wizard resume where they left off.
+
+## Problem Statement
+
+Three concrete friction points exist today:
+
+1. **Cold-start every visit.** The tailoring form (`TailorForm.jsx`) has no concept of a stored Profile. Users re-upload their resume on every single tailor. The `/api/v1/profile` endpoint already exists (`web_app/backend/app/routes/profile.py:35`) but is never invoked from the UI.
+2. **No targeting context.** The pipeline scores every JD identically — there is no notion of "the kind of role I want" or "the companies I care about." Power users (Narendra's own use case) cycle through 3-5 target roles and 20-30 companies. Without persistent targeting, they retype the same context on every run.
+3. **No onboarding.** A new user lands on the tailor form with no idea what an Artifact, a Profile, or a JD even means in this product. Drop-off in the first 60 seconds is the highest-cost failure mode.
+
+Cost of inaction: every returning user repeats 90 seconds of paste-and-upload work; new users churn before producing their first tailored resume.
+
+## Target Users (Primary)
+
+| Persona | Description | Setup Priority |
+|---|---|---|
+| **First-time job seeker (Narendra dog-fooding)** | Has a base resume, knows their target role, has a shortlist of 10-30 companies. | High — designs the wizard. |
+| **Career switcher** | Multiple base resumes (old role + new role). Wants to track which version is "the EM resume" vs "the senior IC resume." | Medium — wizard supports multiple roles. |
+| **Casual returner** | Signed up 3 months ago, forgot the product exists, signs in expecting their setup to still be there. | Medium — must be resumable + editable. |
+
+## User Stories
+
+1. **As a brand-new user**, when I sign up, I see a one-page welcome explaining what the product does and what I'll set up next, so I don't bounce on confusion.
+2. **As a brand-new user**, after the welcome, I'm walked through 3 setup steps (Roles → Companies → Resume Vault) with a clear progress indicator, so I know how much is left.
+3. **As a user selecting target roles**, I can pick from a curated list (Software Engineer, Senior Software Engineer, Staff SWE, Data Engineer, ML Engineer, Product Manager, etc.) OR type a free-form role, so I'm not blocked by an incomplete picklist.
+4. **As a user selecting target companies**, I can pick from a curated list of the top ~200 tech companies, OR type/paste any company name, with autocomplete from my prior entries, so I can build a 20-company watchlist in under 60 seconds.
+5. **As a user setting up my resume vault**, I can upload one base resume (PDF, DOCX, LaTeX, Markdown, or plain text), preview the parsed Profile, edit any field that looks wrong, and confirm — so the parsed Profile becomes the source of truth for all future tailor runs.
+6. **As a user who quit mid-wizard**, when I sign back in, I land on the step I last completed, not the welcome page, so I don't redo finished work.
+7. **As a returning user with setup done**, signing in takes me straight to the tailor form (current behaviour), so the wizard adds zero friction after first run.
+8. **As a returning user**, I can re-enter the wizard from the user menu ("Edit setup") to change my target roles, add companies, or replace my base resume.
+
+## Detailed Flow
+
+### Step 0 — Welcome / Instruction Page (`/setup/welcome`)
+
+Shown immediately after first Clerk sign-up (detected by absence of `setup_completed_at` on the user_profiles row).
+
+**Content:**
+- Headline: "Let's get you set up — takes about 2 minutes."
+- Three numbered cards explaining what each step collects and why:
+  1. **Target roles** → so we know which JD signals matter most to you.
+  2. **Companies to track** → your watchlist; lets us organise saved resumes by employer.
+  3. **Resume vault** → upload once, reuse forever. Powers every tailor run.
+- A single primary CTA: **"Start setup"** → navigates to `/setup/roles`.
+- Secondary text-link: **"Skip for now"** → navigates to the tailor form; sets `setup_skipped_at` but not `setup_completed_at`. The wizard remains reachable from the user menu.
+
+### Step 1 — Target Roles (`/setup/roles`)
+
+**UI:**
+- Multi-select chip grid of ~20 canonical role titles (`CANONICAL_ROLES` constant — see Module 2 below).
+- A "+ Add custom role" affordance that opens a small inline text input.
+- Minimum 1 role required to advance. Maximum 5 (prevents noise; covers the career-switcher case).
+- Selected roles render as removable chips.
+- Progress bar: **Step 1 of 3**.
+- Buttons: **Back** (to welcome), **Continue** (disabled until ≥1 role selected).
+
+**Data shape persisted:**
+```json
+{ "target_roles": ["Senior Data Engineer", "Staff Data Engineer", "ML Platform Engineer"] }
+```
+
+### Step 2 — Target Companies (`/setup/companies`)
+
+**UI:**
+- Hybrid picker + free-text entry.
+- Searchable typeahead input — types match against the canonical list (`CANONICAL_COMPANIES`) AND any previously-entered custom companies.
+- Below the input: chips for already-added companies. Click chip ✕ to remove.
+- Quick-add presets: **"FAANG"**, **"Top fintech"**, **"AI labs"** — clicking adds a curated bundle (user can edit after).
+- Limits: ≥1 company required to advance. Soft warning above 50 ("That's a lot — usually 10–25 yields better focus") but not blocking.
+- Progress bar: **Step 2 of 3**.
+
+**Data shape persisted:**
+```json
+{
+  "target_companies": [
+    {"name": "Stripe", "source": "canonical"},
+    {"name": "Plaid", "source": "canonical"},
+    {"name": "Acme Robotics", "source": "custom"}
+  ]
+}
+```
+
+The `source` field is metadata only; both types behave identically in the watchlist. It exists so we can later improve the canonical list based on what users actually type.
+
+### Step 3 — Resume Vault Setup (`/setup/resume`)
+
+**UI flow:**
+
+1. **Upload zone** — drag-drop or click. Accepts `.pdf`, `.docx`, `.tex`, `.md`, `.txt`. Single file (the base resume).
+   - Alternative: **"Paste resume text instead"** opens a textarea for blob input.
+2. **Parsing feedback** — spinner with "Parsing your resume…" while `POST /api/v1/profile` runs.
+3. **Parsed Profile preview** — read-only collapsible card showing:
+   - Header (name, email, phone, links) — flagged if any field is missing.
+   - Roles (count + first 2 collapsed)
+   - Projects (count)
+   - Skills (top 10)
+   - Education (count)
+   - **Parse quality indicator**: green check if all sections found and Header complete; amber warning if any Header field is missing or roles = 0.
+4. **Edit mode** — clicking any section opens an inline editor. Edits persist via `PATCH /api/v1/profile` (new endpoint — see Module 4).
+5. **Confirmation** — **"This looks right, finish setup"** button finalises:
+   - Sets `setup_completed_at = now()` on `user_profiles`.
+   - Optionally pushes the base resume to the Vault as `is_base_template = true` (gated on `GITHUB_VAULT_TOKEN`).
+   - Redirects to the tailor form with a one-time toast: "Setup complete — your resume vault is ready."
+
+**Progress bar:** **Step 3 of 3**.
+
+### Returning User Flow
+
+- If `setup_completed_at IS NOT NULL` → skip wizard entirely; route directly to tailor form.
+- If `setup_completed_at IS NULL AND setup_skipped_at IS NOT NULL` → still skip wizard; show a dismissible banner at the top of the tailor form: "Finish your setup to enable one-click tailoring → [Resume setup]".
+- If `setup_completed_at IS NULL AND setup_skipped_at IS NULL` → enter wizard at the step indicated by `setup_progress_step` (defaults to `welcome`).
+
+### Edit Setup (Post-First-Run)
+
+User menu adds an **"Edit setup"** item that re-opens the wizard at Step 1 with all current values pre-populated. Each step gets a **"Save & exit"** button so users can update only one section without re-walking the entire flow.
+
+## Acceptance Criteria
+
+### MVP (must ship together)
+
+- [ ] Migration `003_user_setup.sql` adds columns to `user_profiles`: `target_roles JSONB`, `target_companies JSONB`, `setup_completed_at TIMESTAMPTZ`, `setup_skipped_at TIMESTAMPTZ`, `setup_progress_step TEXT`. RLS policies extended to cover new columns.
+- [ ] Backend route `web_app/backend/app/routes/setup.py` exposes:
+  - `GET /api/v1/setup/state` → returns `{ target_roles, target_companies, setup_completed_at, setup_skipped_at, setup_progress_step }`.
+  - `PUT /api/v1/setup/roles` → upsert roles list (max 5).
+  - `PUT /api/v1/setup/companies` → upsert companies list (max 100, soft-warned above 50).
+  - `POST /api/v1/setup/complete` → sets `setup_completed_at = now()`.
+  - `POST /api/v1/setup/skip` → sets `setup_skipped_at = now()` (no completion).
+- [ ] Profile endpoint extended: `PATCH /api/v1/profile` accepts partial JSON edits to the stored Profile (used by Step 3 inline editor).
+- [ ] Frontend route guard in `App.jsx`: signed-in users land on `/setup/welcome` if `setup_completed_at` is null AND `setup_skipped_at` is null. Otherwise current tailor form.
+- [ ] React components added under `web_app/frontend/src/components/setup/`:
+  - `WelcomePage.jsx`
+  - `RolesStep.jsx`
+  - `CompaniesStep.jsx`
+  - `ResumeStep.jsx`
+  - `SetupShell.jsx` — wrapper with progress bar + back/continue logic.
+- [ ] Canonical role + company lists committed at `web_app/frontend/src/constants/setupCatalog.js`. Lists are static JS arrays for MVP (no backend lookup).
+- [ ] User menu has an **"Edit setup"** action that re-enters the wizard with current state.
+- [ ] Resume Step "skip-after-upload" path: if the user uploads but doesn't edit, the parsed Profile is stored as-is and `setup_completed_at` is still written (no forced editing).
+- [ ] All five new components have unit tests with React Testing Library; backend `setup.py` has pytest coverage ≥80%.
+- [ ] No PII in any committed file. Canonical company list contains only well-known public company names.
+
+### Non-MVP (deferred, listed for traceability)
+
+- [ ] Multi-resume vault (multiple base templates tagged by target role). Currently single base resume only.
+- [ ] Company autocomplete backed by an external API (e.g., Crunchbase). MVP uses static list.
+- [ ] Role recommendations based on parsed Profile (e.g., infer "Data Engineer" from skills). MVP requires explicit user pick.
+- [ ] LinkedIn import as an alternative to file upload in Step 3.
+
+## Non-Functional Requirements
+
+- **Performance:**
+  - Welcome page TTI ≤ 500ms (no API calls).
+  - Roles/Companies step responses ≤ 200ms (writes to Supabase only).
+  - Resume Step parsing ≤ 5s for typical PDFs (Tier 0 with `ANTHROPIC_API_KEY`); ≤ 2s for DOCX/LaTeX/plain.
+- **Resumability:** Closing the browser mid-wizard never loses progress. `setup_progress_step` is updated on every `Continue` click.
+- **Accessibility:** All form controls keyboard-navigable. Progress bar has `aria-valuenow`. Step headings are `<h1>` for screen-reader landmarks.
+- **Privacy:** Target roles + companies are user-private (RLS-protected). Never logged. Never sent to Claude or any third party in MVP scope.
+- **Compatibility:** The wizard does not break existing users who already have a Profile row but no setup fields — they're treated as "setup_skipped" (banner shown, full app functional).
+
+## Technical Context
+
+### Existing code touched
+
+- `web_app/frontend/src/App.jsx:24` — add route guard before rendering `TailorForm`.
+- `web_app/backend/app/routes/profile.py` — add `PATCH /profile` for inline edits.
+- `web_app/backend/app/db/supabase.py` — extend `SupabaseProfileStore` with `get_setup_state()`, `update_setup_state()`, plus the SQLite-fallback equivalents per the storage fallback pattern documented in `CLAUDE.md`.
+- `web_app/backend/app/main.py` — register `setup` router.
+
+### New files
+
+```
+web_app/backend/app/routes/setup.py
+migrations/003_user_setup.sql
+web_app/frontend/src/components/setup/SetupShell.jsx
+web_app/frontend/src/components/setup/WelcomePage.jsx
+web_app/frontend/src/components/setup/RolesStep.jsx
+web_app/frontend/src/components/setup/CompaniesStep.jsx
+web_app/frontend/src/components/setup/ResumeStep.jsx
+web_app/frontend/src/constants/setupCatalog.js
+tests/test_setup_routes.py
+web_app/frontend/src/components/setup/__tests__/*.test.jsx
+```
+
+### Patterns to follow
+
+- **Clerk auth via `get_current_user`** dependency on every new route (mirrors `profile.py:36`).
+- **Supabase + SQLite fallback** in the store layer (per `CLAUDE.md` "Storage fallback pattern"). Setup state lives on the same `user_profiles` row, not a new table — keeps the fallback trivial.
+- **React state shape** mirrors the API: a single `useSetupState()` hook calls `GET /api/v1/setup/state` once on mount and exposes `{ state, updateRoles, updateCompanies, complete, skip }`.
+- **Step progression** is data-driven by `setup_progress_step` — frontend never trusts client-side step state alone.
+
+## Module Breakdown
+
+### Module 1 — `migrations/003_user_setup.sql`
+- **Responsibility:** Extend `user_profiles` with setup columns + RLS.
+- **Interface:** SQL applied manually (per migration convention in `migrations/`).
+- **Complexity:** S.
+
+### Module 2 — `web_app/frontend/src/constants/setupCatalog.js`
+- **Responsibility:** Export `CANONICAL_ROLES` (~20 entries) and `CANONICAL_COMPANIES` (~200 entries) + `COMPANY_BUNDLES` (`FAANG`, `Top fintech`, `AI labs`).
+- **Interface:** Static JS module; no I/O.
+- **Complexity:** S.
+
+### Module 3 — `web_app/backend/app/routes/setup.py`
+- **Responsibility:** REST endpoints listed in MVP acceptance criteria above.
+- **Interface:** FastAPI router mounted at `/api/v1/setup`.
+- **Dependencies:** `app.auth.get_current_user`, `app.db.supabase.get_profile_store` (extended).
+- **Complexity:** M.
+
+### Module 4 — `PATCH /api/v1/profile`
+- **Responsibility:** Apply a partial Profile patch (deep-merge into stored JSONB).
+- **Interface:** Adds one handler in `profile.py`; accepts `{ patch: <partial Profile dict> }`.
+- **Dependencies:** Same store as existing `POST /profile`.
+- **Complexity:** S.
+
+### Module 5 — `SetupShell.jsx` + 4 step components
+- **Responsibility:** Render the 4-step wizard with progress bar, route guards, and per-step persistence.
+- **Interface:** Mounted by `App.jsx` route guard; reads/writes via `useSetupState()` hook.
+- **Dependencies:** Clerk `useUser`, the new `/setup/*` endpoints, the existing `/profile` upload endpoint.
+- **Complexity:** L.
+
+### Module 6 — `useSetupState()` hook
+- **Responsibility:** Single source of truth for setup state on the client.
+- **Interface:** `const { state, updateRoles, updateCompanies, uploadResume, patchProfile, complete, skip, loading, error } = useSetupState()`.
+- **Dependencies:** `fetch` + Clerk token.
+- **Complexity:** M.
+
+## Dependency Graph
+
+```
+003_user_setup.sql
+        │
+        ▼
+db/supabase.py (extended)
+        │
+        ▼
+routes/setup.py ──────► routes/profile.py (PATCH added)
+        │                       │
+        └───────────┬───────────┘
+                    ▼
+            useSetupState() hook
+                    │
+   ┌────────────────┼────────────────┐
+   ▼                ▼                ▼
+RolesStep      CompaniesStep    ResumeStep
+   │                │                │
+   └─── SetupShell ◄┴────────────────┘
+                    │
+                    ▼
+              App.jsx guard
+```
+
+Build order: migration → backend store extension → backend routes → frontend hook → step components → shell → App.jsx integration → tests.
+
+## Out of Scope
+
+- Multiple base resumes per user (one-resume-per-user MVP only).
+- LinkedIn OAuth import in Step 3.
+- Company logos in the picker (cost: licensing + asset CDN).
+- Role-specific JD-matching weights wired into the gap analyzer. The wizard *collects* roles in MVP; using them to weight `Signal Categories` is a separate PRD.
+- Email reminders to finish setup for skipped users.
+- Server-rendered welcome page (SSR). MVP is client-rendered like the rest of the SPA.
+
+## Open Questions
+
+1. **Canonical company list source** — bootstrap from the Forbes 500 + YC top 100 lists, or hand-curate ~200 names? Recommend hand-curate for MVP to keep latency and licensing trivial.
+2. **Skip vs Required** — should "Skip for now" be allowed at all? Strict argument: forcing setup raises completion to ~100%. Pragmatic argument: skipping reduces sign-up regret. Recommend allowing skip with a persistent banner.
+3. **Edit-setup re-entry** — should it require typing the password again (Clerk re-auth)? MVP: no. Setup data is not sensitive enough to warrant re-auth friction.
+4. **Vault push at end of Step 3** — auto-push as `is_base_template = true`, or wait until first tailor? Recommend auto-push: the vault is the persistent record, and the user has explicitly confirmed the parse.
+5. **Inline edit fields in Step 3** — full Profile editor or just Header (name/contact)? Recommend Header-only for MVP; Profile section editing is a separate (larger) feature.
+6. **Bundles** — should `FAANG`, `Top fintech`, `AI labs` be hard-coded in the JS catalog or fetched from the backend? Hard-coded is simpler for MVP and lets product iterate on the lists without a deploy gate.
+
+## Success Metrics (post-launch, week 1)
+
+| Metric | Target |
+|---|---|
+| % of new sign-ups that finish all 3 steps | ≥ 70% |
+| Median time to complete the wizard | ≤ 3 minutes |
+| % of returning users (week 2+) who use stored Profile vs. re-uploading | ≥ 80% |
+| Drop-off rate on the welcome page | ≤ 10% |
+| Drop-off rate on the resume upload step | ≤ 20% |
+| Tickets/support requests related to "where do I edit my setup" | ≤ 2 in week 1 |
+
+## Definition of Done
+
+- [ ] All MVP acceptance criteria checked.
+- [ ] `migrations/003_user_setup.sql` applied successfully in Supabase staging.
+- [ ] Backend tests pass: `python -m pytest tests/test_setup_routes.py -v` ≥ 80% coverage.
+- [ ] Frontend tests pass: `npm test` in `web_app/frontend` for all new components.
+- [ ] Manual smoke test: sign up as a brand-new Clerk user, complete the wizard end-to-end, verify the next sign-in skips the wizard and the stored Profile auto-populates the tailor form.
+- [ ] `specs/README.md` updated with an entry under a new date heading documenting the final decisions on the open questions above.
+- [ ] `UBIQUITOUS_LANGUAGE.md` extended with the new terms: **Setup Wizard**, **Target Role**, **Target Company**, **Resume Vault Setup**, **setup_completed_at**, **setup_progress_step**.
+- [ ] No PII committed. RLS verified by attempting cross-user reads in staging.
+- [ ] CI green on Python 3.11 + 3.12.

--- a/tests/test_profile_patch.py
+++ b/tests/test_profile_patch.py
@@ -1,0 +1,84 @@
+"""
+tests/test_profile_patch.py
+Tests for PATCH /api/v1/profile — Epic #91 (M4).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path as _Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = _Path(__file__).parent.parent
+_BACKEND = _REPO_ROOT / "web_app" / "backend"
+_SCRIPTS = _REPO_ROOT / ".claude" / "skills" / "tailor-resume" / "scripts"
+for _p in (_BACKEND, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("CLERK_PEM_KEY", "")
+    import app.config as _cfg
+    _cfg.get_settings.cache_clear()
+    from app.main import create_app
+    return TestClient(create_app(), raise_server_exceptions=True)
+
+
+@pytest.fixture()
+def existing_profile():
+    return {
+        "header": {"name": "Jane Doe", "email": "jane@example.com"},
+        "experience": [{"title": "DE", "company": "Acme"}],
+        "skills": ["Python", "Spark"],
+        "education": [],
+        "projects": [],
+        "certifications": [],
+    }
+
+
+class TestPatchProfile:
+    def test_404_when_no_profile_stored(self, client, monkeypatch):
+        store = MagicMock()
+        store.get.return_value = None
+        monkeypatch.setattr("app.routes.profile.get_profile_store", lambda: store)
+        resp = client.patch("/api/v1/profile", json={"patch": {"header": {"phone": "+1"}}})
+        assert resp.status_code == 404
+
+    def test_merges_nested_dict(self, client, existing_profile, monkeypatch):
+        store = MagicMock()
+        store.get.return_value = existing_profile
+        monkeypatch.setattr("app.routes.profile.get_profile_store", lambda: store)
+        resp = client.patch(
+            "/api/v1/profile",
+            json={"patch": {"header": {"phone": "+1-555"}}},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        # Original name preserved, phone added
+        assert body["profile"]["header"]["name"] == "Jane Doe"
+        assert body["profile"]["header"]["phone"] == "+1-555"
+        store.upsert.assert_called_once()
+
+    def test_list_in_patch_replaces_list_in_storage(self, client, existing_profile, monkeypatch):
+        store = MagicMock()
+        store.get.return_value = existing_profile
+        monkeypatch.setattr("app.routes.profile.get_profile_store", lambda: store)
+        resp = client.patch(
+            "/api/v1/profile",
+            json={"patch": {"skills": ["Rust", "Go"]}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["profile"]["skills"] == ["Rust", "Go"]
+
+    def test_empty_patch_is_noop_but_200(self, client, existing_profile, monkeypatch):
+        store = MagicMock()
+        store.get.return_value = existing_profile
+        monkeypatch.setattr("app.routes.profile.get_profile_store", lambda: store)
+        resp = client.patch("/api/v1/profile", json={"patch": {}})
+        assert resp.status_code == 200
+        assert resp.json()["profile"]["header"]["name"] == "Jane Doe"

--- a/tests/test_setup_routes.py
+++ b/tests/test_setup_routes.py
@@ -1,0 +1,222 @@
+"""
+tests/test_setup_routes.py
+Functional tests for the setup wizard API — Epic #91 (M3).
+
+Mirrors test_web_api.py: TestClient + dev-mode auth bypass + monkeypatched store.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path as _Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = _Path(__file__).parent.parent
+_BACKEND = _REPO_ROOT / "web_app" / "backend"
+_SCRIPTS = _REPO_ROOT / ".claude" / "skills" / "tailor-resume" / "scripts"
+for _p in (_BACKEND, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("CLERK_PEM_KEY", "")
+    import app.config as _cfg
+    _cfg.get_settings.cache_clear()
+    from app.main import create_app
+    return TestClient(create_app(), raise_server_exceptions=True)
+
+
+@pytest.fixture()
+def fake_store(monkeypatch):
+    store = MagicMock()
+    store.get_setup_state.return_value = {
+        "target_roles": [],
+        "target_companies": [],
+        "setup_completed_at": None,
+        "setup_skipped_at": None,
+        "setup_progress_step": "welcome",
+    }
+    monkeypatch.setattr("app.routes.setup.get_profile_store", lambda: store)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# GET /setup/state
+# ---------------------------------------------------------------------------
+
+class TestSetupState:
+    def test_returns_default_state_for_new_user(self, client, fake_store):
+        resp = client.get("/api/v1/setup/state")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["user_id"] == "dev-user"
+        assert body["target_roles"] == []
+        assert body["target_companies"] == []
+        assert body["setup_completed_at"] is None
+        assert body["setup_progress_step"] == "welcome"
+
+    def test_returns_stored_state(self, client, fake_store):
+        fake_store.get_setup_state.return_value = {
+            "target_roles": ["Senior Data Engineer"],
+            "target_companies": [{"name": "Stripe", "source": "canonical"}],
+            "setup_completed_at": "2026-05-01T12:00:00Z",
+            "setup_skipped_at": None,
+            "setup_progress_step": "complete",
+        }
+        resp = client.get("/api/v1/setup/state")
+        assert resp.status_code == 200
+        assert resp.json()["target_roles"] == ["Senior Data Engineer"]
+        assert resp.json()["setup_completed_at"] == "2026-05-01T12:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# PUT /setup/roles
+# ---------------------------------------------------------------------------
+
+class TestPutRoles:
+    def test_accepts_valid_roles(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/roles",
+            json={"roles": ["Senior Data Engineer", "Staff Data Engineer"]},
+        )
+        assert resp.status_code == 200
+        fake_store.update_setup_state.assert_called_once()
+        kwargs = fake_store.update_setup_state.call_args.kwargs
+        assert kwargs["target_roles"] == ["Senior Data Engineer", "Staff Data Engineer"]
+        assert kwargs["setup_progress_step"] == "companies"
+
+    def test_rejects_empty_roles(self, client, fake_store):
+        resp = client.put("/api/v1/setup/roles", json={"roles": []})
+        assert resp.status_code == 422
+
+    def test_rejects_more_than_five_roles(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/roles",
+            json={"roles": [f"Role {i}" for i in range(6)]},
+        )
+        assert resp.status_code == 422
+
+    def test_strips_blank_role_entries(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/roles",
+            json={"roles": ["Senior DE", "   ", "Staff DE"]},
+        )
+        assert resp.status_code == 200
+        kwargs = fake_store.update_setup_state.call_args.kwargs
+        assert kwargs["target_roles"] == ["Senior DE", "Staff DE"]
+
+
+# ---------------------------------------------------------------------------
+# PUT /setup/companies
+# ---------------------------------------------------------------------------
+
+class TestPutCompanies:
+    def test_accepts_valid_companies(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/companies",
+            json={"companies": [
+                {"name": "Stripe", "source": "canonical"},
+                {"name": "Acme Robotics", "source": "custom"},
+            ]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["soft_warning"] is None
+        kwargs = fake_store.update_setup_state.call_args.kwargs
+        assert kwargs["target_companies"][0]["name"] == "Stripe"
+        assert kwargs["setup_progress_step"] == "resume"
+
+    def test_rejects_empty_companies(self, client, fake_store):
+        resp = client.put("/api/v1/setup/companies", json={"companies": []})
+        assert resp.status_code == 422
+
+    def test_rejects_more_than_100_companies(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/companies",
+            json={"companies": [{"name": f"Co{i}", "source": "custom"} for i in range(101)]},
+        )
+        assert resp.status_code == 422
+
+    def test_soft_warns_above_50(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/companies",
+            json={"companies": [{"name": f"Co{i}", "source": "custom"} for i in range(60)]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["soft_warning"] is not None
+        assert "60" in resp.json()["soft_warning"] or "50" in resp.json()["soft_warning"]
+
+    def test_defaults_source_to_custom(self, client, fake_store):
+        resp = client.put(
+            "/api/v1/setup/companies",
+            json={"companies": [{"name": "Stripe"}]},
+        )
+        assert resp.status_code == 200
+        kwargs = fake_store.update_setup_state.call_args.kwargs
+        assert kwargs["target_companies"][0]["source"] == "custom"
+
+
+# ---------------------------------------------------------------------------
+# POST /setup/complete + /setup/skip
+# ---------------------------------------------------------------------------
+
+class TestCompleteSkip:
+    def test_complete_sets_timestamp(self, client, fake_store):
+        resp = client.post("/api/v1/setup/complete")
+        assert resp.status_code == 200
+        kwargs = fake_store.update_setup_state.call_args.kwargs
+        assert "setup_completed_at" in kwargs
+        assert kwargs["setup_progress_step"] == "complete"
+
+    def test_skip_sets_timestamp(self, client, fake_store):
+        resp = client.post("/api/v1/setup/skip")
+        assert resp.status_code == 200
+        kwargs = fake_store.update_setup_state.call_args.kwargs
+        assert "setup_skipped_at" in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Store fallback — SQLite path
+# ---------------------------------------------------------------------------
+
+class TestSqliteStoreSetupState:
+    def test_get_returns_defaults_for_unknown_user(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from app.db.supabase import _SQLiteProfileStore
+        store = _SQLiteProfileStore()
+        state = store.get_setup_state("nobody")
+        assert state["target_roles"] == []
+        assert state["target_companies"] == []
+        assert state["setup_completed_at"] is None
+        assert state["setup_progress_step"] == "welcome"
+
+    def test_update_then_get_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from app.db.supabase import _SQLiteProfileStore
+        store = _SQLiteProfileStore()
+        store.update_setup_state(
+            "alice",
+            target_roles=["Senior DE"],
+            target_companies=[{"name": "Stripe", "source": "canonical"}],
+            setup_progress_step="resume",
+        )
+        state = store.get_setup_state("alice")
+        assert state["target_roles"] == ["Senior DE"]
+        assert state["target_companies"][0]["name"] == "Stripe"
+        assert state["setup_progress_step"] == "resume"
+        assert state["setup_completed_at"] is None
+
+    def test_complete_writes_iso_timestamp(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from app.db.supabase import _SQLiteProfileStore
+        store = _SQLiteProfileStore()
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        store.update_setup_state("alice", setup_completed_at=ts)
+        state = store.get_setup_state("alice")
+        assert state["setup_completed_at"] == ts

--- a/web_app/backend/app/db/supabase.py
+++ b/web_app/backend/app/db/supabase.py
@@ -10,9 +10,19 @@ from __future__ import annotations
 import json
 import os
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from app.config import settings
+
+
+_SETUP_STATE_DEFAULT: Dict[str, Any] = {
+    "target_roles": [],
+    "target_companies": [],
+    "setup_completed_at": None,
+    "setup_skipped_at": None,
+    "setup_progress_step": "welcome",
+}
+_SETUP_STATE_KEYS = tuple(_SETUP_STATE_DEFAULT.keys())
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +63,32 @@ class SupabaseProfileStore:
     def delete(self, user_id: str) -> None:
         self._client.table(self._TABLE).delete().eq("user_id", user_id).execute()
 
+    # ── Setup-wizard state (Epic #91 / M3) ─────────────────────────────────
+
+    def get_setup_state(self, user_id: str) -> Dict[str, Any]:
+        resp = (
+            self._client.table(self._TABLE)
+            .select(",".join(_SETUP_STATE_KEYS))
+            .eq("user_id", user_id)
+            .maybe_single()
+            .execute()
+        )
+        if not resp.data:
+            return dict(_SETUP_STATE_DEFAULT)
+        return {k: resp.data.get(k, _SETUP_STATE_DEFAULT[k]) for k in _SETUP_STATE_KEYS}
+
+    def update_setup_state(self, user_id: str, **fields: Any) -> None:
+        payload: Dict[str, Any] = {"user_id": user_id, "updated_at": "now()"}
+        for k, v in fields.items():
+            if k in _SETUP_STATE_KEYS:
+                payload[k] = v
+        # An upsert requires the NOT NULL profile_json column; if the row
+        # doesn't exist yet, seed it with an empty Profile.
+        existing = self.get(user_id)
+        if existing is None:
+            payload["profile_json"] = {}
+        self._client.table(self._TABLE).upsert(payload, on_conflict="user_id").execute()
+
 
 # ---------------------------------------------------------------------------
 # Factory — returns the right store based on env vars
@@ -88,6 +124,17 @@ class _SQLiteProfileStore:
                 updated_at REAL NOT NULL
             )
         """)
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS user_setup_state (
+                user_id TEXT PRIMARY KEY,
+                target_roles TEXT NOT NULL DEFAULT '[]',
+                target_companies TEXT NOT NULL DEFAULT '[]',
+                setup_completed_at TEXT,
+                setup_skipped_at TEXT,
+                setup_progress_step TEXT NOT NULL DEFAULT 'welcome',
+                updated_at REAL NOT NULL
+            )
+        """)
         self._conn.commit()
 
     def upsert(self, user_id: str, profile: Dict) -> None:
@@ -105,4 +152,46 @@ class _SQLiteProfileStore:
 
     def delete(self, user_id: str) -> None:
         self._conn.execute("DELETE FROM user_profiles WHERE user_id=?", (user_id,))
+        self._conn.execute("DELETE FROM user_setup_state WHERE user_id=?", (user_id,))
+        self._conn.commit()
+
+    # ── Setup-wizard state (Epic #91 / M3) ─────────────────────────────────
+
+    def get_setup_state(self, user_id: str) -> Dict[str, Any]:
+        row = self._conn.execute(
+            """SELECT target_roles, target_companies, setup_completed_at,
+                      setup_skipped_at, setup_progress_step
+                 FROM user_setup_state WHERE user_id=?""",
+            (user_id,),
+        ).fetchone()
+        if row is None:
+            return dict(_SETUP_STATE_DEFAULT)
+        return {
+            "target_roles": json.loads(row[0]),
+            "target_companies": json.loads(row[1]),
+            "setup_completed_at": row[2],
+            "setup_skipped_at": row[3],
+            "setup_progress_step": row[4],
+        }
+
+    def update_setup_state(self, user_id: str, **fields: Any) -> None:
+        current = self.get_setup_state(user_id)
+        for k, v in fields.items():
+            if k in _SETUP_STATE_KEYS:
+                current[k] = v
+        self._conn.execute(
+            """INSERT OR REPLACE INTO user_setup_state
+                 (user_id, target_roles, target_companies, setup_completed_at,
+                  setup_skipped_at, setup_progress_step, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                user_id,
+                json.dumps(current["target_roles"]),
+                json.dumps(current["target_companies"]),
+                current["setup_completed_at"],
+                current["setup_skipped_at"],
+                current["setup_progress_step"],
+                time.time(),
+            ),
+        )
         self._conn.commit()

--- a/web_app/backend/app/main.py
+++ b/web_app/backend/app/main.py
@@ -41,10 +41,12 @@ def create_app() -> FastAPI:
     from app.routes.resume import router as resume_router
     from app.routes.profile import router as profile_router
     from app.routes.billing import router as billing_router
+    from app.routes.setup import router as setup_router
 
     app.include_router(resume_router, prefix=f"/api/{settings.API_VERSION}")
     app.include_router(profile_router, prefix=f"/api/{settings.API_VERSION}")
     app.include_router(billing_router, prefix=f"/api/{settings.API_VERSION}")
+    app.include_router(setup_router, prefix=f"/api/{settings.API_VERSION}")
 
     return app
 

--- a/web_app/backend/app/routes/profile.py
+++ b/web_app/backend/app/routes/profile.py
@@ -28,6 +28,10 @@ class ProfileResponse(BaseModel):
     profile: Dict[str, Any]
 
 
+class ProfilePatchRequest(BaseModel):
+    patch: Dict[str, Any]
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -85,9 +89,44 @@ async def delete_profile(user_id: str = Depends(get_current_user)):
     store.delete(user_id)
 
 
+@router.patch("/profile", response_model=ProfileResponse)
+async def patch_profile(
+    payload: ProfilePatchRequest,
+    user_id: str = Depends(get_current_user),
+):
+    """
+    Apply a partial Profile patch — Epic #91 (M4).
+
+    Deep-merges dicts; lists in `patch` replace lists in storage.
+    404 if no Profile is stored yet.
+    """
+    store = get_profile_store()
+    existing = store.get(user_id)
+    if existing is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Profile not found")
+
+    merged = _deep_merge(existing, payload.patch or {})
+    store.upsert(user_id, merged)
+    return ProfileResponse(user_id=user_id, profile=merged)
+
+
 # ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
+
+def _deep_merge(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursive dict merge: dicts merge, lists/scalars in patch replace base."""
+    result: Dict[str, Any] = dict(base)
+    for key, value in patch.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(result.get(key), dict)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
 
 def _parse_to_dict(artifact_bytes: bytes, artifact_format: str) -> Dict[str, Any]:
     """Parse resume bytes to a Profile dict using the tailor-resume parsers."""

--- a/web_app/backend/app/routes/setup.py
+++ b/web_app/backend/app/routes/setup.py
@@ -1,0 +1,183 @@
+"""
+app/routes/setup.py
+First-run setup wizard endpoints — Epic #91 (M3).
+
+GET    /setup/state       — return the user's current wizard state
+PUT    /setup/roles       — upsert target roles (1..5)
+PUT    /setup/companies   — upsert target companies (1..100, soft warning ≥50)
+POST   /setup/complete    — finalise the wizard
+POST   /setup/skip        — record skip, keep wizard reachable
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.auth import get_current_user
+from app.db.supabase import get_profile_store
+
+router = APIRouter(tags=["setup"])
+
+_MAX_ROLES = 5
+_MAX_COMPANIES = 100
+_SOFT_WARN_COMPANY_COUNT = 50
+_SOURCE_CANONICAL = "canonical"
+_SOURCE_CUSTOM = "custom"
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+class CompanyEntry(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    source: str = _SOURCE_CUSTOM
+
+
+class SetupStateResponse(BaseModel):
+    user_id: str
+    target_roles: List[str]
+    target_companies: List[CompanyEntry]
+    setup_completed_at: Optional[str] = None
+    setup_skipped_at: Optional[str] = None
+    setup_progress_step: str = "welcome"
+
+
+class RolesRequest(BaseModel):
+    roles: List[str] = Field(..., min_length=1, max_length=_MAX_ROLES)
+
+
+class CompaniesRequest(BaseModel):
+    companies: List[CompanyEntry] = Field(..., min_length=1, max_length=_MAX_COMPANIES)
+
+
+class MutationResponse(BaseModel):
+    user_id: str
+    setup_progress_step: str
+    soft_warning: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _state_to_response(user_id: str, state: Dict[str, Any]) -> SetupStateResponse:
+    return SetupStateResponse(
+        user_id=user_id,
+        target_roles=list(state.get("target_roles") or []),
+        target_companies=[
+            CompanyEntry(**c) if isinstance(c, dict) else CompanyEntry(name=str(c))
+            for c in (state.get("target_companies") or [])
+        ],
+        setup_completed_at=state.get("setup_completed_at"),
+        setup_skipped_at=state.get("setup_skipped_at"),
+        setup_progress_step=state.get("setup_progress_step") or "welcome",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/setup/state", response_model=SetupStateResponse)
+async def get_state(user_id: str = Depends(get_current_user)):
+    store = get_profile_store()
+    state = store.get_setup_state(user_id)
+    return _state_to_response(user_id, state)
+
+
+@router.put("/setup/roles", response_model=MutationResponse)
+async def put_roles(
+    payload: RolesRequest,
+    user_id: str = Depends(get_current_user),
+):
+    cleaned = [r.strip() for r in payload.roles if r and r.strip()]
+    if not cleaned:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one non-empty role required",
+        )
+    if len(cleaned) > _MAX_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"At most {_MAX_ROLES} roles allowed",
+        )
+    store = get_profile_store()
+    store.update_setup_state(
+        user_id,
+        target_roles=cleaned,
+        setup_progress_step="companies",
+    )
+    return MutationResponse(user_id=user_id, setup_progress_step="companies")
+
+
+@router.put("/setup/companies", response_model=MutationResponse)
+async def put_companies(
+    payload: CompaniesRequest,
+    user_id: str = Depends(get_current_user),
+):
+    companies: List[Dict[str, str]] = []
+    for entry in payload.companies:
+        name = entry.name.strip()
+        if not name:
+            continue
+        source = entry.source.strip() if entry.source else _SOURCE_CUSTOM
+        if source not in (_SOURCE_CANONICAL, _SOURCE_CUSTOM):
+            source = _SOURCE_CUSTOM
+        companies.append({"name": name, "source": source})
+
+    if not companies:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one company required",
+        )
+
+    soft_warning: Optional[str] = None
+    if len(companies) >= _SOFT_WARN_COMPANY_COUNT:
+        soft_warning = (
+            f"You added {len(companies)} companies — usually 10–25 yields better focus."
+        )
+
+    store = get_profile_store()
+    store.update_setup_state(
+        user_id,
+        target_companies=companies,
+        setup_progress_step="resume",
+    )
+    return MutationResponse(
+        user_id=user_id,
+        setup_progress_step="resume",
+        soft_warning=soft_warning,
+    )
+
+
+@router.post("/setup/complete", response_model=MutationResponse)
+async def post_complete(user_id: str = Depends(get_current_user)):
+    store = get_profile_store()
+    store.update_setup_state(
+        user_id,
+        setup_completed_at=_now_iso(),
+        setup_progress_step="complete",
+    )
+    return MutationResponse(user_id=user_id, setup_progress_step="complete")
+
+
+@router.post("/setup/skip", response_model=MutationResponse)
+async def post_skip(user_id: str = Depends(get_current_user)):
+    store = get_profile_store()
+    store.update_setup_state(
+        user_id,
+        setup_skipped_at=_now_iso(),
+    )
+    state = store.get_setup_state(user_id)
+    return MutationResponse(
+        user_id=user_id,
+        setup_progress_step=state.get("setup_progress_step") or "welcome",
+    )

--- a/web_app/frontend/src/App.css
+++ b/web_app/frontend/src/App.css
@@ -606,3 +606,235 @@ textarea {
     padding: 0 16px;
   }
 }
+
+/* ============================================================
+   Setup wizard (Epic #91)
+   ============================================================ */
+
+.setup-shell {
+  max-width: 760px;
+  margin: 32px auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px;
+  box-shadow: var(--shadow);
+}
+
+.setup-header h1 { margin-bottom: 16px; }
+
+.setup-progress {
+  position: relative;
+  height: 8px;
+  background: var(--surface-2);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+.setup-progress-bar {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.3s;
+}
+.setup-progress-label {
+  display: block;
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+
+.setup-body { margin-top: 24px; }
+.setup-loading { display: flex; justify-content: center; padding: 64px; }
+.setup-error {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid var(--red);
+  color: var(--red);
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  margin-bottom: 16px;
+}
+
+.setup-welcome .setup-lede { color: var(--text-dim); margin: 8px 0 24px; }
+.setup-cards { list-style: none; display: grid; gap: 12px; margin-bottom: 24px; }
+.setup-cards li {
+  background: var(--surface-2);
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+.setup-cards strong { display: block; margin-bottom: 4px; }
+.setup-cards p { color: var(--text-dim); font-size: 14px; }
+
+.setup-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn-primary:hover:not(:disabled) { background: var(--accent-hover); }
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 16px 0;
+}
+.chip {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.chip-selected { background: var(--accent); color: #fff; border-color: var(--accent); }
+.chip-removable { display: inline-flex; align-items: center; gap: 6px; }
+.chip-removable button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+.chip-canonical { border-color: var(--accent); }
+
+.custom-row, .company-search {
+  display: flex;
+  gap: 8px;
+  margin: 16px 0;
+}
+.custom-row input, .company-search input {
+  flex: 1;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+}
+
+.bundle-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.company-suggestions {
+  list-style: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  padding: 4px;
+  margin-bottom: 16px;
+}
+.company-suggestions li button {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text);
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.company-suggestions li button:hover { background: var(--surface); }
+
+.selected-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 16px;
+}
+.selected-label { color: var(--text-dim); margin-right: 8px; font-size: 13px; }
+
+.soft-warning {
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid var(--amber);
+  color: var(--amber);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  margin-top: 12px;
+}
+
+.upload-zone {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 24px;
+  background: var(--surface-2);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  margin: 16px 0;
+}
+.profile-preview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin: 16px 0;
+}
+.preview-card {
+  background: var(--surface-2);
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+.preview-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.preview-card ul { list-style: none; font-size: 14px; }
+.preview-card li { padding: 2px 0; color: var(--text-dim); }
+.preview-card em { color: var(--text-muted); }
+.preview-editing label { display: block; margin: 8px 0; font-size: 13px; }
+.preview-editing input {
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 8px;
+  border-radius: 4px;
+  margin-top: 2px;
+}
+.quality-badge {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.quality-badge.green { background: rgba(34, 197, 94, 0.15); color: var(--green); }
+.quality-badge.amber { background: rgba(245, 158, 11, 0.15); color: var(--amber); }
+
+.setup-banner {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  margin: 16px 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-dim);
+  font-size: 14px;
+}

--- a/web_app/frontend/src/App.jsx
+++ b/web_app/frontend/src/App.jsx
@@ -1,33 +1,84 @@
-import React, { useState } from 'react'
-import { useUser, useClerk, SignIn } from '@clerk/clerk-react'
+import React, { useEffect, useState } from 'react'
+import { useUser, useClerk, useAuth, SignIn } from '@clerk/clerk-react'
 import TailorForm from './components/TailorForm.jsx'
 import ResultPanel from './components/ResultPanel.jsx'
+import SetupShell from './components/setup/SetupShell.jsx'
 import './App.css'
 
-function UserMenu() {
+const API_BASE = import.meta.env.VITE_API_URL || ''
+
+function UserMenu({ onEditSetup }) {
   const { user } = useUser()
   const { signOut } = useClerk()
   return (
     <div className="user-menu">
       <span className="user-email">{user?.primaryEmailAddress?.emailAddress}</span>
+      <button className="btn-ghost" onClick={onEditSetup}>Edit setup</button>
       <button className="btn-ghost" onClick={() => signOut()}>Sign out</button>
+    </div>
+  )
+}
+
+function SetupBanner({ onResume }) {
+  return (
+    <div className="setup-banner">
+      <span>Finish your setup to enable one-click tailoring.</span>
+      <button className="btn-link" onClick={onResume}>Resume setup</button>
     </div>
   )
 }
 
 export default function App() {
   const { isSignedIn, isLoaded } = useUser()
+  const { getToken } = useAuth()
+
+  const [setupState, setSetupState] = useState(null)
+  const [setupLoading, setSetupLoading] = useState(true)
+  const [forceWizard, setForceWizard] = useState(false)
+
   const [result, setResult] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
 
-  if (!isLoaded) {
+  // Fetch wizard state on sign-in so we can decide the route.
+  useEffect(() => {
+    if (!isSignedIn) {
+      setSetupLoading(false)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      setSetupLoading(true)
+      try {
+        const token = await getToken()
+        const resp = await fetch(`${API_BASE}/api/v1/setup/state`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        })
+        const data = resp.ok ? await resp.json() : null
+        if (!cancelled) setSetupState(data)
+      } catch {
+        if (!cancelled) setSetupState(null)
+      } finally {
+        if (!cancelled) setSetupLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isSignedIn, getToken, forceWizard])
+
+  if (!isLoaded || (isSignedIn && setupLoading)) {
     return (
       <div className="app-loading">
         <div className="spinner" />
       </div>
     )
   }
+
+  const setupCompleted = !!setupState?.setup_completed_at
+  const setupSkipped = !!setupState?.setup_skipped_at
+  const showWizard =
+    isSignedIn && (forceWizard || (!setupCompleted && !setupSkipped))
 
   return (
     <div className="app">
@@ -37,7 +88,7 @@ export default function App() {
           <h1>Tailor Resume</h1>
           <span className="header-tagline">AI-powered resume optimizer</span>
         </div>
-        {isSignedIn && <UserMenu />}
+        {isSignedIn && <UserMenu onEditSetup={() => setForceWizard(true)} />}
       </header>
 
       <main className="app-main">
@@ -49,20 +100,35 @@ export default function App() {
               <SignIn routing="hash" />
             </div>
           </div>
+        ) : showWizard ? (
+          <SetupShell
+            onDone={() => {
+              setForceWizard(false)
+              setSetupState((prev) => ({
+                ...(prev || {}),
+                setup_completed_at: prev?.setup_completed_at || new Date().toISOString(),
+              }))
+            }}
+          />
         ) : (
-          <div className="two-pane">
-            <div className="pane pane-left">
-              <TailorForm
-                onResult={setResult}
-                onLoading={setLoading}
-                onError={setError}
-                loading={loading}
-              />
+          <>
+            {setupSkipped && !setupCompleted && (
+              <SetupBanner onResume={() => setForceWizard(true)} />
+            )}
+            <div className="two-pane">
+              <div className="pane pane-left">
+                <TailorForm
+                  onResult={setResult}
+                  onLoading={setLoading}
+                  onError={setError}
+                  loading={loading}
+                />
+              </div>
+              <div className="pane pane-right">
+                <ResultPanel result={result} loading={loading} error={error} />
+              </div>
             </div>
-            <div className="pane pane-right">
-              <ResultPanel result={result} loading={loading} error={error} />
-            </div>
-          </div>
+          </>
         )}
       </main>
     </div>

--- a/web_app/frontend/src/components/setup/CompaniesStep.jsx
+++ b/web_app/frontend/src/components/setup/CompaniesStep.jsx
@@ -1,0 +1,122 @@
+// web_app/frontend/src/components/setup/CompaniesStep.jsx
+// Step 2 — target companies (picker + free-text + bundles) — Epic #91 (M5).
+
+import React from 'react'
+import { CANONICAL_COMPANIES, COMPANY_BUNDLES } from '../../constants/setupCatalog.js'
+
+const MAX_COMPANIES = 100
+const SOFT_WARN = 50
+
+export default function CompaniesStep({ initialCompanies = [], onBack, onContinue }) {
+  const [companies, setCompanies] = React.useState(() =>
+    (initialCompanies || []).map((c) => (typeof c === 'string' ? { name: c, source: 'custom' } : c)),
+  )
+  const [query, setQuery] = React.useState('')
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const names = new Set(companies.map((c) => c.name.toLowerCase()))
+
+  const suggestions = React.useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return []
+    return CANONICAL_COMPANIES.filter(
+      (c) => c.toLowerCase().includes(q) && !names.has(c.toLowerCase()),
+    ).slice(0, 8)
+  }, [query, companies])
+
+  const add = (name, source) => {
+    const cleaned = name.trim()
+    if (!cleaned) return
+    if (names.has(cleaned.toLowerCase())) return
+    if (companies.length >= MAX_COMPANIES) return
+    setCompanies((prev) => [...prev, { name: cleaned, source }])
+    setQuery('')
+  }
+
+  const addCustomFromInput = () => {
+    if (!query.trim()) return
+    const canonical = CANONICAL_COMPANIES.find(
+      (c) => c.toLowerCase() === query.trim().toLowerCase(),
+    )
+    add(query, canonical ? 'canonical' : 'custom')
+  }
+
+  const remove = (name) =>
+    setCompanies((prev) => prev.filter((c) => c.name !== name))
+
+  const addBundle = (bundleName) => {
+    const bundle = COMPANY_BUNDLES[bundleName] || []
+    bundle.forEach((name) => add(name, 'canonical'))
+  }
+
+  const canContinue = companies.length >= 1 && !submitting
+  const softWarning =
+    companies.length >= SOFT_WARN
+      ? `That's a lot — usually 10–25 yields better focus.`
+      : null
+
+  const submit = async () => {
+    setSubmitting(true)
+    try {
+      await onContinue(companies)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="setup-step setup-companies">
+      <h2>Which companies are you tracking?</h2>
+      <p>Pick from the list, paste in your own, or load a bundle.</p>
+
+      <div className="bundle-row">
+        {Object.keys(COMPANY_BUNDLES).map((b) => (
+          <button key={b} type="button" className="btn-ghost" onClick={() => addBundle(b)}>
+            + {b}
+          </button>
+        ))}
+      </div>
+
+      <div className="company-search">
+        <input
+          type="text"
+          placeholder="Type a company name…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && addCustomFromInput()}
+        />
+        <button type="button" disabled={!query.trim()} onClick={addCustomFromInput}>
+          + Add
+        </button>
+      </div>
+
+      {suggestions.length > 0 && (
+        <ul className="company-suggestions">
+          {suggestions.map((s) => (
+            <li key={s}>
+              <button type="button" onClick={() => add(s, 'canonical')}>{s}</button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="selected-chips">
+        {companies.map((c) => (
+          <span key={c.name} className={`chip chip-removable chip-${c.source}`}>
+            {c.name}
+            <button onClick={() => remove(c.name)} aria-label={`Remove ${c.name}`}>×</button>
+          </span>
+        ))}
+      </div>
+
+      {softWarning && <div className="soft-warning">{softWarning}</div>}
+
+      <footer className="setup-actions">
+        <button className="btn-ghost" onClick={onBack}>Back</button>
+        <button className="btn-primary" disabled={!canContinue} onClick={submit}>
+          Continue
+        </button>
+      </footer>
+    </section>
+  )
+}

--- a/web_app/frontend/src/components/setup/ResumeStep.jsx
+++ b/web_app/frontend/src/components/setup/ResumeStep.jsx
@@ -1,0 +1,155 @@
+// web_app/frontend/src/components/setup/ResumeStep.jsx
+// Step 3 — base resume upload + parse preview + confirm — Epic #91 (M5).
+
+import React from 'react'
+
+export default function ResumeStep({ onBack, onUpload, onPatch, onFinish }) {
+  const [file, setFile] = React.useState(null)
+  const [profile, setProfile] = React.useState(null)
+  const [editingHeader, setEditingHeader] = React.useState(false)
+  const [headerDraft, setHeaderDraft] = React.useState({})
+  const [busy, setBusy] = React.useState(false)
+  const [error, setError] = React.useState(null)
+
+  const upload = async () => {
+    if (!file) return
+    setBusy(true)
+    setError(null)
+    try {
+      const data = await onUpload(file)
+      setProfile(data.profile)
+      setHeaderDraft(data.profile.header || {})
+    } catch (e) {
+      setError(e.message || String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const saveHeader = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const data = await onPatch({ header: headerDraft })
+      setProfile(data.profile)
+      setEditingHeader(false)
+    } catch (e) {
+      setError(e.message || String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const finish = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await onFinish()
+    } catch (e) {
+      setError(e.message || String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="setup-step setup-resume">
+      <h2>Upload your base resume</h2>
+      <p>PDF, DOCX, LaTeX, Markdown, or plain text. We'll parse it once; you reuse it forever.</p>
+
+      <div className="upload-zone">
+        <input
+          type="file"
+          accept=".pdf,.docx,.tex,.md,.txt"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <button className="btn-primary" disabled={!file || busy} onClick={upload}>
+          {busy ? 'Parsing…' : 'Upload & parse'}
+        </button>
+      </div>
+
+      {error && <div className="setup-error">{error}</div>}
+
+      {profile && (
+        <div className="profile-preview">
+          <PreviewHeader
+            header={profile.header}
+            editing={editingHeader}
+            draft={headerDraft}
+            onDraftChange={setHeaderDraft}
+            onEdit={() => setEditingHeader(true)}
+            onCancel={() => {
+              setHeaderDraft(profile.header || {})
+              setEditingHeader(false)
+            }}
+            onSave={saveHeader}
+            busy={busy}
+          />
+          <PreviewStats profile={profile} />
+        </div>
+      )}
+
+      <footer className="setup-actions">
+        <button className="btn-ghost" onClick={onBack}>Back</button>
+        <button className="btn-primary" disabled={!profile || busy} onClick={finish}>
+          This looks right — finish setup
+        </button>
+      </footer>
+    </section>
+  )
+}
+
+function PreviewHeader({ header = {}, editing, draft, onDraftChange, onEdit, onCancel, onSave, busy }) {
+  if (!editing) {
+    const missing = !header.name || !header.email
+    return (
+      <div className="preview-card">
+        <header>
+          <strong>Header</strong>
+          <button className="btn-link" onClick={onEdit}>Edit</button>
+        </header>
+        <ul>
+          <li>Name: {header.name || <em>missing</em>}</li>
+          <li>Email: {header.email || <em>missing</em>}</li>
+          <li>Phone: {header.phone || <em>—</em>}</li>
+          <li>LinkedIn: {header.linkedin || <em>—</em>}</li>
+        </ul>
+        <span className={`quality-badge ${missing ? 'amber' : 'green'}`}>
+          {missing ? 'Some fields missing' : 'Looks good'}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <div className="preview-card preview-editing">
+      <header><strong>Edit header</strong></header>
+      <label>Name <input value={draft.name || ''} onChange={(e) => onDraftChange({ ...draft, name: e.target.value })} /></label>
+      <label>Email <input value={draft.email || ''} onChange={(e) => onDraftChange({ ...draft, email: e.target.value })} /></label>
+      <label>Phone <input value={draft.phone || ''} onChange={(e) => onDraftChange({ ...draft, phone: e.target.value })} /></label>
+      <label>LinkedIn <input value={draft.linkedin || ''} onChange={(e) => onDraftChange({ ...draft, linkedin: e.target.value })} /></label>
+      <div className="setup-actions">
+        <button className="btn-ghost" onClick={onCancel} disabled={busy}>Cancel</button>
+        <button className="btn-primary" onClick={onSave} disabled={busy}>Save header</button>
+      </div>
+    </div>
+  )
+}
+
+function PreviewStats({ profile }) {
+  const counts = {
+    Roles: (profile.experience || []).length,
+    Projects: (profile.projects || []).length,
+    Skills: (profile.skills || []).length,
+    Education: (profile.education || []).length,
+  }
+  return (
+    <div className="preview-card preview-stats">
+      <header><strong>Parsed sections</strong></header>
+      <ul>
+        {Object.entries(counts).map(([k, v]) => (
+          <li key={k}>{k}: {v}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/web_app/frontend/src/components/setup/RolesStep.jsx
+++ b/web_app/frontend/src/components/setup/RolesStep.jsx
@@ -1,0 +1,94 @@
+// web_app/frontend/src/components/setup/RolesStep.jsx
+// Step 1 — target roles (chips + custom add) — Epic #91 (M5).
+
+import React from 'react'
+import { CANONICAL_ROLES } from '../../constants/setupCatalog.js'
+
+const MAX_ROLES = 5
+
+export default function RolesStep({ initialRoles = [], onBack, onContinue }) {
+  const [selected, setSelected] = React.useState(initialRoles)
+  const [customRole, setCustomRole] = React.useState('')
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const toggle = (role) => {
+    setSelected((prev) =>
+      prev.includes(role)
+        ? prev.filter((r) => r !== role)
+        : prev.length < MAX_ROLES
+          ? [...prev, role]
+          : prev,
+    )
+  }
+
+  const addCustom = () => {
+    const cleaned = customRole.trim()
+    if (!cleaned || selected.includes(cleaned) || selected.length >= MAX_ROLES) return
+    setSelected((prev) => [...prev, cleaned])
+    setCustomRole('')
+  }
+
+  const canContinue = selected.length >= 1 && !submitting
+
+  const submit = async () => {
+    setSubmitting(true)
+    try {
+      await onContinue(selected)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="setup-step setup-roles">
+      <h2>Which roles are you targeting?</h2>
+      <p>Pick up to {MAX_ROLES}. We'll weight matching signals accordingly.</p>
+
+      <div className="chip-grid">
+        {CANONICAL_ROLES.map((role) => (
+          <button
+            key={role}
+            type="button"
+            className={`chip ${selected.includes(role) ? 'chip-selected' : ''}`}
+            onClick={() => toggle(role)}
+            aria-pressed={selected.includes(role)}
+          >
+            {role}
+          </button>
+        ))}
+      </div>
+
+      <div className="custom-row">
+        <input
+          type="text"
+          placeholder="Add a custom role…"
+          value={customRole}
+          onChange={(e) => setCustomRole(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && addCustom()}
+        />
+        <button type="button" onClick={addCustom} disabled={!customRole.trim()}>
+          + Add
+        </button>
+      </div>
+
+      {selected.length > 0 && (
+        <div className="selected-chips">
+          <span className="selected-label">Selected:</span>
+          {selected.map((r) => (
+            <span key={r} className="chip chip-removable">
+              {r}
+              <button onClick={() => toggle(r)} aria-label={`Remove ${r}`}>×</button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <footer className="setup-actions">
+        <button className="btn-ghost" onClick={onBack}>Back</button>
+        <button className="btn-primary" disabled={!canContinue} onClick={submit}>
+          Continue
+        </button>
+      </footer>
+    </section>
+  )
+}

--- a/web_app/frontend/src/components/setup/SetupShell.jsx
+++ b/web_app/frontend/src/components/setup/SetupShell.jsx
@@ -1,0 +1,103 @@
+// web_app/frontend/src/components/setup/SetupShell.jsx
+// Wizard shell with progress bar + step routing — Epic #91 (M5).
+
+import React from 'react'
+import { useSetupState } from './useSetupState.js'
+import WelcomePage from './WelcomePage.jsx'
+import RolesStep from './RolesStep.jsx'
+import CompaniesStep from './CompaniesStep.jsx'
+import ResumeStep from './ResumeStep.jsx'
+
+const STEPS = ['welcome', 'roles', 'companies', 'resume']
+const STEP_LABELS = {
+  welcome: 'Welcome',
+  roles: 'Target roles',
+  companies: 'Companies',
+  resume: 'Resume vault',
+}
+
+export default function SetupShell({ onDone }) {
+  const setup = useSetupState()
+  const [localStep, setLocalStep] = React.useState(null)
+
+  if (setup.loading) {
+    return (
+      <div className="setup-shell setup-loading">
+        <div className="spinner" />
+      </div>
+    )
+  }
+
+  const activeStep = localStep || setup.state.setup_progress_step || 'welcome'
+  const stepIdx = Math.max(0, STEPS.indexOf(activeStep))
+
+  function goTo(step) {
+    setLocalStep(step)
+  }
+
+  return (
+    <div className="setup-shell">
+      <header className="setup-header">
+        <h1>Set up your account</h1>
+        <ProgressBar current={stepIdx} total={STEPS.length} />
+      </header>
+
+      {setup.error && <div className="setup-error">{setup.error}</div>}
+
+      <main className="setup-body">
+        {activeStep === 'welcome' && (
+          <WelcomePage
+            onStart={() => goTo('roles')}
+            onSkip={async () => {
+              await setup.skip()
+              onDone?.()
+            }}
+          />
+        )}
+        {activeStep === 'roles' && (
+          <RolesStep
+            initialRoles={setup.state.target_roles}
+            onBack={() => goTo('welcome')}
+            onContinue={async (roles) => {
+              await setup.updateRoles(roles)
+              goTo('companies')
+            }}
+          />
+        )}
+        {activeStep === 'companies' && (
+          <CompaniesStep
+            initialCompanies={setup.state.target_companies}
+            onBack={() => goTo('roles')}
+            onContinue={async (companies) => {
+              await setup.updateCompanies(companies)
+              goTo('resume')
+            }}
+          />
+        )}
+        {activeStep === 'resume' && (
+          <ResumeStep
+            onBack={() => goTo('companies')}
+            onUpload={setup.uploadResume}
+            onPatch={setup.patchProfile}
+            onFinish={async () => {
+              await setup.complete()
+              onDone?.()
+            }}
+          />
+        )}
+      </main>
+    </div>
+  )
+}
+
+function ProgressBar({ current, total }) {
+  const pct = Math.min(100, Math.round(((current + 1) / total) * 100))
+  return (
+    <div className="setup-progress" role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100}>
+      <div className="setup-progress-bar" style={{ width: `${pct}%` }} />
+      <span className="setup-progress-label">
+        Step {current + 1} of {total} — {STEP_LABELS[STEPS[current]] || ''}
+      </span>
+    </div>
+  )
+}

--- a/web_app/frontend/src/components/setup/WelcomePage.jsx
+++ b/web_app/frontend/src/components/setup/WelcomePage.jsx
@@ -1,0 +1,35 @@
+// web_app/frontend/src/components/setup/WelcomePage.jsx
+// Step 0 — orientation and dual CTA (Start / Skip) — Epic #91 (M5).
+
+import React from 'react'
+
+export default function WelcomePage({ onStart, onSkip }) {
+  return (
+    <section className="setup-welcome">
+      <h2>Let's get you set up — takes about 2 minutes.</h2>
+      <p className="setup-lede">
+        Three quick steps unlock one-click tailoring on every future visit.
+      </p>
+
+      <ol className="setup-cards">
+        <li>
+          <strong>1. Target roles</strong>
+          <p>So we know which JD signals matter most to you.</p>
+        </li>
+        <li>
+          <strong>2. Companies to track</strong>
+          <p>Your watchlist. Saved resumes get organised by employer.</p>
+        </li>
+        <li>
+          <strong>3. Resume vault</strong>
+          <p>Upload once. Every tailor run reuses your base profile.</p>
+        </li>
+      </ol>
+
+      <div className="setup-actions">
+        <button className="btn-primary" onClick={onStart}>Start setup</button>
+        <button className="btn-link" onClick={onSkip}>Skip for now</button>
+      </div>
+    </section>
+  )
+}

--- a/web_app/frontend/src/components/setup/useSetupState.js
+++ b/web_app/frontend/src/components/setup/useSetupState.js
@@ -1,0 +1,128 @@
+// web_app/frontend/src/components/setup/useSetupState.js
+// Single source of truth for the setup wizard on the client — Epic #91 (M6).
+
+import { useCallback, useEffect, useState } from 'react'
+import { useAuth } from '@clerk/clerk-react'
+
+const API_BASE = import.meta.env.VITE_API_URL || ''
+
+const DEFAULT_STATE = {
+  user_id: '',
+  target_roles: [],
+  target_companies: [],
+  setup_completed_at: null,
+  setup_skipped_at: null,
+  setup_progress_step: 'welcome',
+}
+
+export function useSetupState() {
+  const { getToken } = useAuth()
+  const [state, setState] = useState(DEFAULT_STATE)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const authedFetch = useCallback(
+    async (path, opts = {}) => {
+      const token = await getToken()
+      const headers = { ...(opts.headers || {}) }
+      if (token) headers['Authorization'] = `Bearer ${token}`
+      if (opts.body && !(opts.body instanceof FormData)) {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json'
+      }
+      const resp = await fetch(`${API_BASE}${path}`, { ...opts, headers })
+      if (!resp.ok) {
+        const detail = await resp.text().catch(() => resp.statusText)
+        throw new Error(`${resp.status} ${detail}`)
+      }
+      if (resp.status === 204) return null
+      return resp.json()
+    },
+    [getToken],
+  )
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await authedFetch('/api/v1/setup/state')
+      setState({ ...DEFAULT_STATE, ...data })
+    } catch (e) {
+      setError(e.message || String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [authedFetch])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const updateRoles = useCallback(
+    async (roles) => {
+      const data = await authedFetch('/api/v1/setup/roles', {
+        method: 'PUT',
+        body: JSON.stringify({ roles }),
+      })
+      await refresh()
+      return data
+    },
+    [authedFetch, refresh],
+  )
+
+  const updateCompanies = useCallback(
+    async (companies) => {
+      const data = await authedFetch('/api/v1/setup/companies', {
+        method: 'PUT',
+        body: JSON.stringify({ companies }),
+      })
+      await refresh()
+      return data
+    },
+    [authedFetch, refresh],
+  )
+
+  const uploadResume = useCallback(
+    async (file) => {
+      const fd = new FormData()
+      fd.append('artifact', file)
+      const data = await authedFetch('/api/v1/profile', { method: 'POST', body: fd })
+      return data
+    },
+    [authedFetch],
+  )
+
+  const patchProfile = useCallback(
+    async (patch) => {
+      return authedFetch('/api/v1/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ patch }),
+      })
+    },
+    [authedFetch],
+  )
+
+  const complete = useCallback(async () => {
+    const data = await authedFetch('/api/v1/setup/complete', { method: 'POST' })
+    await refresh()
+    return data
+  }, [authedFetch, refresh])
+
+  const skip = useCallback(async () => {
+    const data = await authedFetch('/api/v1/setup/skip', { method: 'POST' })
+    await refresh()
+    return data
+  }, [authedFetch, refresh])
+
+  return {
+    state,
+    loading,
+    error,
+    refresh,
+    updateRoles,
+    updateCompanies,
+    uploadResume,
+    patchProfile,
+    complete,
+    skip,
+  }
+}

--- a/web_app/frontend/src/constants/setupCatalog.js
+++ b/web_app/frontend/src/constants/setupCatalog.js
@@ -1,0 +1,73 @@
+// web_app/frontend/src/constants/setupCatalog.js
+// Static catalog for the first-run setup wizard — Epic #91 (M2).
+// No I/O. No deps. Public company names only.
+
+export const CANONICAL_ROLES = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'Staff Software Engineer',
+  'Principal Software Engineer',
+  'Engineering Manager',
+  'Data Engineer',
+  'Senior Data Engineer',
+  'Staff Data Engineer',
+  'Analytics Engineer',
+  'ML Engineer',
+  'ML Platform Engineer',
+  'Data Scientist',
+  'Senior Data Scientist',
+  'Product Manager',
+  'Senior Product Manager',
+  'Engineering Lead',
+  'Solutions Architect',
+  'Site Reliability Engineer',
+  'Platform Engineer',
+  'Full Stack Engineer',
+]
+
+export const CANONICAL_COMPANIES = [
+  // Big tech
+  'Apple', 'Google', 'Microsoft', 'Amazon', 'Meta', 'Netflix', 'Nvidia',
+  // AI labs
+  'Anthropic', 'OpenAI', 'Cohere', 'Mistral AI', 'Hugging Face', 'Perplexity',
+  // Fintech
+  'Stripe', 'Plaid', 'Block', 'Adyen', 'Brex', 'Ramp', 'Affirm', 'Robinhood',
+  'Coinbase', 'Wise', 'Mercury', 'Chime', 'Klarna',
+  // Data / DevTools
+  'Snowflake', 'Databricks', 'Confluent', 'MongoDB', 'Elastic', 'HashiCorp',
+  'GitHub', 'GitLab', 'Datadog', 'New Relic', 'Splunk', 'PagerDuty',
+  'Fivetran', 'dbt Labs', 'Airbyte', 'Prefect', 'Astronomer',
+  // SaaS / Productivity
+  'Atlassian', 'Notion', 'Linear', 'Figma', 'Canva', 'Asana', 'Monday.com',
+  'Zoom', 'Slack', 'Dropbox', 'Box', 'DocuSign', 'Twilio', 'Zendesk',
+  // E-commerce / Marketplaces
+  'Shopify', 'Etsy', 'eBay', 'Airbnb', 'Booking.com', 'Expedia',
+  'Uber', 'Lyft', 'DoorDash', 'Instacart', 'Wayfair',
+  // Streaming / Media
+  'Spotify', 'Disney', 'Roku', 'Hulu', 'Pinterest', 'Reddit', 'Snap',
+  'TikTok', 'Discord',
+  // Enterprise / Cloud
+  'Salesforce', 'Oracle', 'SAP', 'ServiceNow', 'Workday', 'VMware', 'IBM',
+  'Cisco', 'Cloudflare', 'Akamai', 'Fastly',
+  // Hardware / Auto
+  'Tesla', 'Rivian', 'SpaceX', 'AMD', 'Intel', 'Qualcomm',
+  // Consulting / Finance
+  'McKinsey', 'BCG', 'Bain', 'Deloitte', 'Accenture',
+  'Goldman Sachs', 'Morgan Stanley', 'JPMorgan Chase', 'BlackRock', 'Citadel',
+  'Two Sigma', 'Jane Street', 'Hudson River Trading',
+  // Logistics / Industry
+  'FedEx', 'UPS', 'Walmart', 'Target', 'Costco',
+  // Bio / Health tech
+  'Moderna', 'Pfizer', 'Genentech', 'Illumina', '23andMe', 'Tempus',
+  // Misc unicorns
+  'Palantir', 'CrowdStrike', 'Okta', 'Snowflake', 'ZScaler', 'Wiz',
+  'Anduril', 'Scale AI', 'Replit', 'Vercel', 'Netlify', 'Supabase',
+  'Clerk', 'PostHog', 'Sentry', 'Retool', 'Airtable',
+]
+
+// Convenience bundles — each item must also exist in CANONICAL_COMPANIES above.
+export const COMPANY_BUNDLES = {
+  FAANG: ['Meta', 'Apple', 'Amazon', 'Netflix', 'Google'],
+  'Top fintech': ['Stripe', 'Plaid', 'Block', 'Brex', 'Ramp', 'Coinbase', 'Mercury'],
+  'AI labs': ['Anthropic', 'OpenAI', 'Cohere', 'Mistral AI', 'Hugging Face', 'Perplexity'],
+}


### PR DESCRIPTION
Closes #91 (epic). Closes #92 #93 #94 #95 #96 #97.

Adds a 3-step setup wizard (target roles → companies → resume vault) gated on `setup_completed_at`. Returning users skip it. Skip is allowed and reversible via "Edit setup" in the user menu.

## Commits

1. `docs(specs): add PRD for login + first-run setup wizard` — `specs/prd_login_setup.md` (310 lines)
2. `feat(setup): first-run onboarding wizard` — implementation across backend + frontend + tests

## What's in this PR

### Backend
- `migrations/003_user_setup.sql` — adds `target_roles`, `target_companies`, `setup_completed_at`, `setup_skipped_at`, `setup_progress_step` to `user_profiles`. Idempotent (`ADD COLUMN IF NOT EXISTS`).
- `app/routes/setup.py` — 5 endpoints:
  - `GET /api/v1/setup/state`
  - `PUT /api/v1/setup/roles` (1–5 enforced)
  - `PUT /api/v1/setup/companies` (1–100, soft-warn at 50)
  - `POST /api/v1/setup/complete`
  - `POST /api/v1/setup/skip`
- `app/routes/profile.py` — new `PATCH /api/v1/profile` (deep-merge dicts, list-replacement, 404 if no Profile)
- `app/db/supabase.py` — store extended with `get_setup_state` / `update_setup_state` on **both** Supabase and SQLite-fallback paths (per the storage-fallback pattern in `CLAUDE.md`)
- `app/main.py` — registers the new router

### Frontend
- `constants/setupCatalog.js` — 20 canonical roles, ~120 companies, FAANG / Top fintech / AI labs bundles
- `components/setup/SetupShell.jsx` — progress bar + step routing
- `components/setup/WelcomePage.jsx` — Step 0 (intro + Start / Skip)
- `components/setup/RolesStep.jsx` — Step 1 (chip multi-select + custom add)
- `components/setup/CompaniesStep.jsx` — Step 2 (picker + free-text + bundles + soft warning ≥50)
- `components/setup/ResumeStep.jsx` — Step 3 (upload → parse → preview → header edit → finish)
- `components/setup/useSetupState.js` — single source of truth for the wizard on the client
- `App.jsx` — route guard: signed-in users with no `setup_completed_at` and no `setup_skipped_at` land on the wizard; "Edit setup" in user menu re-enters
- `App.css` — wizard styles (chips, progress bar, preview cards, soft warning)

## Tests (TDD red → green)

- `tests/test_setup_routes.py` — 16 cases (all endpoints + SQLite store roundtrip)
- `tests/test_profile_patch.py` — 4 cases (404, nested-dict merge, list-replacement, empty-patch noop)
- **45/45 green** on clean state, no regressions
- Coverage: `routes/setup.py` **94%**, `routes/profile.py` **82%** (both above the 80% gate)

## Test plan

- [ ] Apply `migrations/003_user_setup.sql` in Supabase staging
- [ ] `pip install -r web_app/backend/requirements.txt`
- [ ] `PYTHONPATH=web_app/backend python -m pytest tests/test_setup_routes.py tests/test_profile_patch.py -v` → 20 pass
- [ ] `PYTHONPATH=web_app/backend python -m pytest tests/test_web_api.py tests/test_billing.py -v` → no regressions
- [ ] `cd web_app/frontend && npm install && npm run build` → builds clean
- [ ] Manual smoke: sign up as a fresh Clerk user → walk wizard end-to-end → verify next sign-in skips it
- [ ] Manual smoke: sign up, click "Skip for now" → banner appears on tailor form → "Resume setup" re-enters wizard
- [ ] Manual smoke: completed user clicks "Edit setup" → wizard re-opens at Welcome → "Skip for now" preserves prior data

## Deploy (after merge)

```bash
# Apply migration in Supabase
psql "$SUPABASE_URL" -f migrations/003_user_setup.sql

# Backend
cd web_app && fly deploy --remote-only

# Frontend
cd web_app/frontend && npm run build  # then ship via Vercel
```

## Out of scope (deferred — see PRD)

- Multi-resume vault (one base resume only in MVP)
- LinkedIn OAuth import
- Role-specific weighting in the JD gap analyzer
- Email reminders for skipped users

https://claude.ai/code/session_01EwdnvLAvY88tsd7L7Gz19E

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwdnvLAvY88tsd7L7Gz19E)_