### PR TITLE
feat(deploy): add deployment-readiness check + 4 parser-bug issues filed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install optional dependencies (mcp, pinecone, openai)
         run: pip install -r requirements-optional.txt
 
+      - name: Deployment readiness check (critical deps installed)
+        run: python scripts/check_deployment_readiness.py
+
       - name: Lint with ruff
         run: python -m ruff check .claude/skills/tailor-resume/scripts/ tests/
 

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,14 @@ OUT         := out
 MCP_SERVER  := $(SCRIPTS)/mcp_server.py
 MCP_GLOBAL  := $(HOME)/.claude/.mcp.json
 
-.PHONY: setup setup-all install-global demo test test-cov lint render mcp-serve mcp-install-global sync-global serve clean help
+.PHONY: setup setup-all install-global demo test test-cov lint render mcp-serve mcp-install-global sync-global serve clean check-deps help
 
 help:
 	@echo "Available targets:"
 	@echo "  install-global       Copy skill + register MCP + install optional deps (run once after clone)"
 	@echo "  setup                Install core dev dependencies (pytest, ruff)"
 	@echo "  setup-all            Install core + optional deps (pinecone, openai, mcp)"
+	@echo "  check-deps           Smoke-test critical runtime deps (fails CI on missing pdfminer/pypdf)"
 	@echo "  demo                 Run the full pipeline on sample fixtures -> $(OUT)/resume.tex"
 	@echo "  test                 Run the test suite"
 	@echo "  test-cov             Run tests with coverage report"
@@ -30,6 +31,9 @@ setup:
 
 setup-all:
 	$(PYTHON) -m pip install -r requirements.txt -r requirements-optional.txt
+
+check-deps:
+	$(PYTHON) scripts/check_deployment_readiness.py
 
 demo: $(OUT)
 	$(PYTHON) $(SCRIPTS)/profile_extractor.py \

--- a/scripts/check_deployment_readiness.py
+++ b/scripts/check_deployment_readiness.py
@@ -1,0 +1,141 @@
+"""
+check_deployment_readiness.py
+
+Smoke-test critical runtime dependencies for the tailor-resume deployments.
+
+Run as `make check-deps`, or before a deploy, or in CI. Exits non-zero if any
+CRITICAL dep is missing — so a broken environment is caught before the pipeline
+silently degrades to garbage PDF parsing.
+
+Critical deps were chosen because their absence causes *silent quality
+degradation* (parser falls back to a lower tier and produces wrong output
+without raising). Recommended/optional deps degrade only a single feature
+without affecting the rest of the pipeline.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class DepCheck:
+    """Result of importing a single dependency."""
+
+    package: str       # pip-installable name
+    module: str        # import name (may differ from pip name)
+    importable: bool
+    severity: str      # "critical" | "recommended" | "optional"
+    impact: str        # what breaks when missing
+    install_hint: str  # exact command to fix
+
+
+# (pip_name, import_name, severity, impact_when_missing, install_command)
+_DEPS = [
+    (
+        "pdfminer.six",
+        "pdfminer",
+        "critical",
+        "PDF extraction falls through to the stdlib tier, which mangles "
+        "Jake-template / LaTeX-generated PDFs (pipe separators become 'j', "
+        "bullet glyphs become 'ffi', section detection breaks).",
+        "pip install pdfminer.six",
+    ),
+    (
+        "pypdf",
+        "pypdf",
+        "critical",
+        "PDF extraction skips the second tier and falls all the way to stdlib.",
+        "pip install pypdf",
+    ),
+    (
+        "python-docx",
+        "docx",
+        "recommended",
+        ".docx upload uses the stdlib fallback extractor with limited fidelity.",
+        "pip install python-docx",
+    ),
+    (
+        "anthropic",
+        "anthropic",
+        "recommended",
+        "Claude-vision PDF fallback disabled. PDFs that fail all parser tiers "
+        "can't be retried via the vision API.",
+        "pip install anthropic",
+    ),
+    (
+        "fastapi",
+        "fastapi",
+        "optional",
+        "Web backend (web_app) won't start. CLI and Streamlit are unaffected.",
+        "pip install fastapi uvicorn python-multipart",
+    ),
+    (
+        "streamlit",
+        "streamlit",
+        "optional",
+        "Streamlit UI won't start. CLI and FastAPI backend are unaffected.",
+        "pip install streamlit",
+    ),
+]
+
+
+def check_all() -> List[DepCheck]:
+    """Run every dep check and return the result list in declaration order."""
+    results: List[DepCheck] = []
+    for pip_name, import_name, severity, impact, hint in _DEPS:
+        try:
+            __import__(import_name)
+            ok = True
+        except ImportError:
+            ok = False
+        results.append(
+            DepCheck(
+                package=pip_name,
+                module=import_name,
+                importable=ok,
+                severity=severity,
+                impact=impact,
+                install_hint=hint,
+            )
+        )
+    return results
+
+
+def critical_missing(checks: List[DepCheck]) -> List[DepCheck]:
+    """Subset of `checks` that are missing AND tagged 'critical'."""
+    return [c for c in checks if not c.importable and c.severity == "critical"]
+
+
+def format_report(checks: List[DepCheck]) -> str:
+    """Render the readiness report as a human-readable multi-line string."""
+    lines = ["Deployment readiness check", "=" * 60]
+    for c in checks:
+        status = "OK" if c.importable else "MISSING"
+        lines.append(f"  [{status:>7s}] {c.package:<14s}  ({c.severity})")
+        if not c.importable:
+            lines.append(f"            impact : {c.impact}")
+            lines.append(f"            fix    : {c.install_hint}")
+    lines.append("=" * 60)
+    missing = critical_missing(checks)
+    if missing:
+        names = ", ".join(c.package for c in missing)
+        lines.append(
+            f"FAILED: {len(missing)} critical dep(s) missing ({names}) — "
+            "deployment will silently produce broken output."
+        )
+    else:
+        lines.append("PASS: all critical deps installed.")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Print the readiness report and return exit code 0 (pass) or 1 (fail)."""
+    checks = check_all()
+    print(format_report(checks))
+    return 1 if critical_missing(checks) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/streamlit_app/tabs/profile_tab.py
+++ b/streamlit_app/tabs/profile_tab.py
@@ -50,12 +50,28 @@ def render():
 
     # ---- File upload -------------------------------------------------------
     if input_mode == "Upload file":
+        # Surface missing critical PDF deps as a hard error (not a soft warning)
+        # so the user knows uploads will silently produce garbage if they go ahead.
+        _scripts_dir = os.path.join(_REPO, "scripts")
+        if _scripts_dir not in sys.path:
+            sys.path.insert(0, _scripts_dir)
         try:
-            import pdfminer  # noqa: F401
+            from check_deployment_readiness import check_all, critical_missing
+            checks = check_all()
+            missing = critical_missing(checks)
+            for c in missing:
+                st.error(
+                    f"❌ Missing critical dependency `{c.package}` — {c.impact} "
+                    f"Fix: `{c.install_hint}`"
+                )
         except ImportError:
-            st.warning(
-                "PDF parsing quality is degraded — run `pip install pdfminer.six` for best results."
-            )
+            # Fallback to the inline check if the readiness module isn't present.
+            try:
+                import pdfminer  # noqa: F401
+            except ImportError:
+                st.warning(
+                    "PDF parsing quality is degraded — run `pip install pdfminer.six` for best results."
+                )
         if not os.environ.get("ANTHROPIC_API_KEY"):
             st.info(
                 "Tip: Set ANTHROPIC_API_KEY to enable AI-powered PDF parsing — "

--- a/tests/test_check_deployment_readiness.py
+++ b/tests/test_check_deployment_readiness.py
@@ -1,0 +1,184 @@
+"""Tests for scripts/check_deployment_readiness.py."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from check_deployment_readiness import (  # noqa: E402
+    DepCheck,
+    check_all,
+    critical_missing,
+    format_report,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_all
+# ---------------------------------------------------------------------------
+
+class TestCheckAll:
+    def test_returns_list_of_dep_checks(self):
+        result = check_all()
+        assert isinstance(result, list)
+        assert all(isinstance(c, DepCheck) for c in result)
+
+    def test_includes_critical_pdf_deps(self):
+        result = check_all()
+        package_names = {c.package for c in result}
+        assert "pdfminer.six" in package_names
+        assert "pypdf" in package_names
+
+    def test_every_severity_is_known(self):
+        valid = {"critical", "recommended", "optional"}
+        for c in check_all():
+            assert c.severity in valid, f"{c.package} has unknown severity {c.severity!r}"
+
+    def test_every_critical_dep_has_install_hint(self):
+        for c in check_all():
+            if c.severity == "critical":
+                assert c.install_hint.startswith("pip install"), (
+                    f"{c.package} install_hint should be a pip command, got {c.install_hint!r}"
+                )
+
+    def test_every_dep_has_non_empty_impact(self):
+        for c in check_all():
+            assert c.impact and len(c.impact) > 20, (
+                f"{c.package} impact should be a descriptive sentence"
+            )
+
+    def test_results_are_in_stable_order(self):
+        """Two consecutive calls return the same package order — important for deterministic CI output."""
+        first = [c.package for c in check_all()]
+        second = [c.package for c in check_all()]
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# critical_missing
+# ---------------------------------------------------------------------------
+
+class TestCriticalMissing:
+    def test_filters_to_missing_critical_only(self):
+        checks = [
+            DepCheck("a", "a", False, "critical", "impact a", "pip install a"),
+            DepCheck("b", "b", True, "critical", "impact b", "pip install b"),
+            DepCheck("c", "c", False, "recommended", "impact c", "pip install c"),
+            DepCheck("d", "d", False, "optional", "impact d", "pip install d"),
+        ]
+        missing = critical_missing(checks)
+        assert len(missing) == 1
+        assert missing[0].package == "a"
+
+    def test_empty_when_all_critical_installed(self):
+        checks = [
+            DepCheck("a", "a", True, "critical", "impact a", "pip install a"),
+            DepCheck("b", "b", False, "recommended", "impact b", "pip install b"),
+        ]
+        assert critical_missing(checks) == []
+
+
+# ---------------------------------------------------------------------------
+# format_report
+# ---------------------------------------------------------------------------
+
+class TestFormatReport:
+    def test_all_ok_report_says_pass(self):
+        checks = [
+            DepCheck("a", "a", True, "critical", "impact a", "pip install a"),
+            DepCheck("b", "b", True, "optional", "impact b", "pip install b"),
+        ]
+        report = format_report(checks)
+        assert "PASS" in report
+        assert "FAILED" not in report
+
+    def test_missing_critical_report_says_failed(self):
+        checks = [
+            DepCheck("a", "a", False, "critical", "impact a", "pip install a"),
+            DepCheck("b", "b", True, "recommended", "impact b", "pip install b"),
+        ]
+        report = format_report(checks)
+        assert "FAILED" in report
+        assert "PASS" not in report
+        assert "(a)" in report  # names listed in failure summary
+
+    def test_missing_critical_includes_impact_and_fix(self):
+        checks = [
+            DepCheck("foo", "foo", False, "critical",
+                     "foo breaks bar baz qux", "pip install foo")
+        ]
+        report = format_report(checks)
+        assert "impact" in report
+        assert "foo breaks bar baz qux" in report
+        assert "pip install foo" in report
+
+    def test_missing_recommended_does_not_say_failed(self):
+        """Missing recommended deps don't fail the overall report."""
+        checks = [DepCheck("a", "a", False, "recommended",
+                           "impact a longer than twenty chars sentence",
+                           "pip install a")]
+        report = format_report(checks)
+        assert "PASS" in report
+
+    def test_status_column_uses_OK_or_MISSING(self):
+        checks = [
+            DepCheck("a", "a", True, "critical", "impact a long enough sentence here please",
+                     "pip install a"),
+            DepCheck("b", "b", False, "optional", "impact b long enough sentence here please",
+                     "pip install b"),
+        ]
+        report = format_report(checks)
+        assert "OK" in report
+        assert "MISSING" in report
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def test_returns_zero_when_all_critical_present(self, capsys, monkeypatch):
+        fake = [
+            DepCheck("a", "a", True, "critical", "impact a long sentence here please thanks",
+                     "pip install a"),
+            DepCheck("b", "b", False, "optional", "impact b long sentence here please thanks",
+                     "pip install b"),
+        ]
+        monkeypatch.setattr("check_deployment_readiness.check_all", lambda: fake)
+        rc = main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "PASS" in out
+
+    def test_returns_one_when_critical_missing(self, capsys, monkeypatch):
+        fake = [DepCheck("a", "a", False, "critical",
+                         "impact a long sentence here please thanks", "pip install a")]
+        monkeypatch.setattr("check_deployment_readiness.check_all", lambda: fake)
+        rc = main()
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "FAILED" in out
+
+
+# ---------------------------------------------------------------------------
+# Real-environment smoke check (no monkeypatching)
+# ---------------------------------------------------------------------------
+
+class TestRealEnvironment:
+    """Verifies the live test environment has the critical deps.
+
+    This is the single most useful test in this file from a CI perspective —
+    if a future PR removes a critical dep from requirements.txt and breaks
+    deployments silently, this test fails loudly.
+    """
+
+    def test_critical_deps_installed_in_test_env(self):
+        checks = check_all()
+        missing = critical_missing(checks)
+        assert missing == [], (
+            f"Critical deps missing in test env: {[c.package for c in missing]}. "
+            "This means requirements.txt is incomplete or stale. CI is supposed "
+            "to install everything in requirements.txt before running tests."
+        )

--- a/web_app/backend/app/main.py
+++ b/web_app/backend/app/main.py
@@ -6,6 +6,7 @@ Pattern mirrors autoapply-ai: create_app() returns a configured FastAPI instance
 """
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -18,6 +19,31 @@ from app.config import settings
 _SCRIPTS_DIR = Path(__file__).parent.parent.parent.parent / ".claude" / "skills" / "tailor-resume" / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# Make deploy-time utilities (readiness check) importable
+_REPO_SCRIPTS_DIR = Path(__file__).parent.parent.parent.parent / "scripts"
+if str(_REPO_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_REPO_SCRIPTS_DIR))
+
+logger = logging.getLogger(__name__)
+
+
+def _log_deployment_readiness() -> None:
+    """Log the readiness report on startup so missing PDF deps are visible in container logs."""
+    try:
+        from check_deployment_readiness import check_all, critical_missing, format_report
+        checks = check_all()
+        missing = critical_missing(checks)
+        if missing:
+            # Loud warning — deployment will produce broken output until fixed.
+            logger.error("Deployment readiness: %d CRITICAL dep(s) missing", len(missing))
+            for c in missing:
+                logger.error("  MISSING %s — %s. Fix: %s", c.package, c.impact, c.install_hint)
+        else:
+            logger.info(format_report(checks).splitlines()[-1])  # "PASS: all critical deps installed."
+    except ImportError:
+        # Don't let a missing readiness module take down the API.
+        logger.warning("check_deployment_readiness module unavailable; skipping startup dep check")
 
 
 def create_app() -> FastAPI:
@@ -47,6 +73,11 @@ def create_app() -> FastAPI:
     app.include_router(profile_router, prefix=f"/api/{settings.API_VERSION}")
     app.include_router(billing_router, prefix=f"/api/{settings.API_VERSION}")
     app.include_router(setup_router, prefix=f"/api/{settings.API_VERSION}")
+
+    # ── Startup readiness check (surfaces missing pdfminer/pypdf in logs) ──
+    @app.on_event("startup")
+    def _on_startup() -> None:
+        _log_deployment_readiness()
 
     return app
 


### PR DESCRIPTION
## Motivation
A user uploaded a Jake-template resume PDF (`Naren_citi.pdf`) to the Streamlit app and got back garbage: **0 roles, 0 bullets, 18 mangled "skills"** with characters like `jlinkedin.com/...` and `PipelinejPySpark`. Root cause: `pdfminer.six` was missing in their deployment, so `parse_pdf` fell all the way to the stdlib extractor. The stdlib tier mangles LaTeX-generated PDFs (pipe separator `|` → `j`, bullet glyph `•` → `ffi`). The Streamlit UI emitted only a soft warning before proceeding.

This PR makes missing critical deps a **loud failure** at every entry point so the same silent-degradation pattern can't recur.

## Changes
- **new** `scripts/check_deployment_readiness.py` — module + CLI that imports each dep and classifies it:
  - **critical** (absence causes silent quality degradation): `pdfminer.six`, `pypdf`
  - **recommended** (feature removed, pipeline still works): `python-docx`, `anthropic`
  - **optional** (specific entry point unaffects others): `fastapi`, `streamlit`
  - Exits 1 if any critical dep is missing.
- **new** `tests/test_check_deployment_readiness.py` — 16 tests, including a `TestRealEnvironment::test_critical_deps_installed_in_test_env` that fails CI if `requirements.txt` is incomplete or stale.
- **CI** (`.github/workflows/ci.yml`) — new "Deployment readiness check" step runs the script before lint/tests. Catches dep drift in PRs before merge.
- **Makefile** — `make check-deps` target.
- **Streamlit** (`streamlit_app/tabs/profile_tab.py`) — upgrades the pdfminer-only soft warning to a hard `st.error()` for every missing critical dep, listing the runtime impact and exact pip command. Users can no longer silently upload a PDF when extraction will be broken.
- **FastAPI** (`web_app/backend/app/main.py`) — logs the readiness report on startup so missing deps are visible in container logs.

## Sample output (all deps present)
```
Deployment readiness check
============================================================
  [     OK] pdfminer.six    (critical)
  [     OK] pypdf           (critical)
  [     OK] python-docx     (recommended)
  [     OK] anthropic       (recommended)
  [     OK] fastapi         (optional)
  [     OK] streamlit       (optional)
============================================================
PASS: all critical deps installed.
```

## Sample output (broken env, what the user hit)
```
Deployment readiness check
============================================================
  [MISSING] pdfminer.six    (critical)
            impact : PDF extraction falls through to the stdlib tier, which mangles Jake-template / LaTeX-generated PDFs ...
            fix    : pip install pdfminer.six
  [     OK] pypdf           (critical)
  ...
============================================================
FAILED: 1 critical dep(s) missing (pdfminer.six) — deployment will silently produce broken output.
```

## Coverage delta
- Total project: **88% → 89.11%** (CI gate 86%)
- 16/16 new tests pass; existing suite unaffected

## Companion issues (parser bugs the broken PDF exposed)
- #101 — first role's title gets the candidate's name
- #102 — nth role's title gets parsed as the start date
- #103 — project name = bullet text (pipe-separated project header ignored)
- #104 — bullets dropped from every role with two-line headers

These are separate parser fixes that don't block this PR.

## Test plan
- [x] `python scripts/check_deployment_readiness.py` exits 0 with all deps present
- [x] `make check-deps` matches
- [x] `pytest tests/test_check_deployment_readiness.py` → 16/16
- [x] `pytest tests/ --cov-fail-under=86` → 89.11% total
- [x] `ruff check` clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_