### PR TITLE
fix(deploy): slim requirements.txt + add packages.txt so Streamlit Cloud installs pdfminer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: pip
 
       - name: Install core dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Install optional dependencies (mcp, pinecone, openai)
         run: pip install -r requirements-optional.txt

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ help:
 	@echo "  clean                Remove generated output files"
 
 setup:
-	$(PYTHON) -m pip install -r requirements.txt
+	$(PYTHON) -m pip install -r requirements.txt -r requirements-dev.txt
 
 setup-all:
-	$(PYTHON) -m pip install -r requirements.txt -r requirements-optional.txt
+	$(PYTHON) -m pip install -r requirements.txt -r requirements-dev.txt -r requirements-optional.txt
 
 check-deps:
 	$(PYTHON) scripts/check_deployment_readiness.py

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,2 @@
+build-essential
+libffi-dev

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# Dev / testing tooling.
+# Not installed by Streamlit Cloud or production Docker images — keeps
+# their builds lean and isolates wheel-build problems to the dev image only.
+
+# Test framework + coverage
+pytest>=7.4
+pytest-cov>=4.1
+
+# Linter
+ruff>=0.4
+
+# Used by tests/fixtures/parsers/_make_pdf.py to regenerate sample.pdf;
+# also imported lazily by tests/test_parsers_integration.py if the binary
+# fixture is missing.
+reportlab>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,22 @@
-# Core — stdlib only for parsing/analysis/rendering
-# Python 3.11+ required
+# Runtime dependencies for the tailor-resume Streamlit app and CLI pipeline.
+# Streamlit Community Cloud installs this file at build time.
+# Dev-only tooling (pytest, ruff, reportlab) lives in requirements-dev.txt.
+#
+# Python version is pinned in `runtime.txt` (python-3.11) for Streamlit Cloud
+# compatibility — pdfminer.six's cffi/cryptography stack has had wheel-build
+# issues on Python 3.13 that silently abort the install, leaving the
+# deployment without pdfminer.six AND without pypdf.
 
-# Streamlit web app (also used by Streamlit Community Cloud)
+# Web UI
 streamlit>=1.32.0
 
-# File parsing — PDF and DOCX upload support
+# File parsing — PDF and DOCX upload support.
+# Order matters on some build environments: pdfminer.six first so the heavier
+# native build runs early; if it fails the run aborts loudly instead of
+# partway through optional deps.
+pdfminer.six>=20221105
 pypdf>=4.0
 python-docx>=1.0
 
 # LLM-based enrichment (Claude for bullet quality + user preference feedback)
 anthropic>=0.27
-
-# LLM-free PDF extraction — reads ToUnicode CMap for correct Unicode (LaTeX CMR fonts)
-pdfminer.six>=20221105
-
-# Dev / testing
-pytest>=7.4
-pytest-cov>=4.1
-ruff>=0.4
-# Used by tests/fixtures/parsers/_make_pdf.py to regenerate sample.pdf;
-# also imported lazily by tests/test_parsers_integration.py if the binary
-# fixture is missing.
-reportlab>=4.0


### PR DESCRIPTION
## Motivation
After PR #105 (deployment-readiness check) merged, a user rebooted `tailor-resume-ai.streamlit.app` and saw the new red banner correctly flagging that **both `pdfminer.six` and `pypdf` were missing** — even though both are in `requirements.txt`. Streamlit Cloud's pip install was bailing partway through.

![readiness banner showing pdfminer.six and pypdf both missing](https://github.com/narendranathe/tailor-resume/issues/56)

## Two contributing causes

1. **`requirements.txt` mixed runtime deps with dev-only tooling** (`pytest`, `pytest-cov`, `ruff`, `reportlab`). When any of those failed to build wheels on Streamlit Cloud, the install run aborted before reaching `pdfminer.six` / `pypdf`. Split into:
   - `requirements.txt` — runtime only (streamlit, pdfminer.six, pypdf, python-docx, anthropic)
   - `requirements-dev.txt` — pytest, pytest-cov, ruff, reportlab (reportlab is only used by `tests/fixtures/parsers/_make_pdf.py`)

2. **`pdfminer.six` pulls in `cffi`/`cryptography`** which sometimes need `libffi-dev` and `build-essential` at compile time when binary wheels aren't available for the runtime. Added `packages.txt` at repo root — Streamlit Cloud installs these via `apt-get` before the pip step.

## Also done
- Reordered `requirements.txt` to put `pdfminer.six` first so the heavier native build runs early — if it fails the run aborts loudly instead of partway through downstream deps.
- `runtime.txt` already pinned `python-3.11` (no change needed).
- `Makefile` (`make setup`, `make setup-all`) and `.github/workflows/ci.yml` now install both `requirements.txt` and `requirements-dev.txt` so existing local + CI test runs are unaffected.

## Files
```
.github/workflows/ci.yml |  2 +-
Makefile                 |  4 ++--
packages.txt             |  2 ++   (NEW: build-essential, libffi-dev)
requirements-dev.txt     | 15 ++++  (NEW: pytest, pytest-cov, ruff, reportlab)
requirements.txt         | 30 +/-   (slim to runtime only, pdfminer first)
```

## Test plan
- [x] `pytest tests/ --cov-fail-under=86` → 974 passed (same 3 pre-existing web_api state-pollution failures, unrelated to this PR)
- [x] `ruff check` clean
- [x] `make check-deps` still passes (readiness module unchanged)
- [ ] CI green
- [ ] After merge: reboot tailor-resume-ai.streamlit.app, readiness banner clears, `Naren_citi.pdf` parses correctly using the parser fixes from #106

## Follow-up (after this lands)
1. You reboot tailor-resume-ai on Streamlit Cloud.
2. Confirm the readiness banner is gone.
3. Upload `Naren_citi.pdf` again — expected result is 3 roles, 10 bullets, 2 projects per my local repro on latest `main`.

If pdfminer/pypdf STILL fail to install after this PR, the Streamlit Cloud build logs will tell us exactly which package is breaking and we can target the next fix precisely.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_