### PR TITLE
chore(streamlit): cache-bust comment to force Streamlit Cloud source refresh

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,3 +1,5 @@
+# Streamlit Cloud cache-bust: 2026-05-17 — forces source refresh after #106/#108
+# (parser fixes + correct requirements.txt) didn't apply due to stale source cache.
 import sys
 import os
 


### PR DESCRIPTION
## Why
Streamlit Cloud picked up the new `requirements.txt` from PR #108 (banner is gone, `pdfminer.six` + `pypdf` are installed), but kept the **pre-#106 Python source code in cache**. Net effect: `Naren_citi.pdf` still parses via the old buggy `plain_parser` — 0 bullets per role, candidate name as first role's title, bullet text as project names. Exactly the bug pattern from #101–#104 that we fixed in #106.

Verified locally on current `main`: the same PDF parses correctly to 3 roles / 10 bullets / 2 named projects. So this is purely a Streamlit Cloud cache miss, not a code bug.

## What
A 2-line comment in `streamlit_app/app.py`. Changes the source SHA so Streamlit Cloud re-clones the repo and re-builds from latest `main` instead of reusing the stale cached source tree.

## After merge
You reboot Streamlit Cloud one more time (or it auto-deploys within ~1 min). Then `Naren_citi.pdf` should parse with the #106 logic and produce:
- 3 roles: Data Engineer @ ExponentHR (5 bullets), Data Engineer @ Missouri S&T (3 bullets), Business Analyst @ Zomato (2 bullets)
- 2 projects: Real-Time Fraud Detection Pipeline, JobScout
- 32 skills, 1 education, 1 certification

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_