### PR TITLE
fix(streamlit): correct sys.path order + delegate plain_parser to fixed modular version

### DIFF
--- a/.claude/skills/tailor-resume/scripts/parsers/plain_parser.py
+++ b/.claude/skills/tailor-resume/scripts/parsers/plain_parser.py
@@ -162,7 +162,17 @@ def _parse_plain_resume_text(text: str, source: str = "resume") -> Profile:
     n = len(lines)
     # #101 fix: start in 'preamble' so the candidate-name line at the top of
     # the resume does not get treated as the title of an implicit first role.
-    section: Optional[str] = "preamble"
+    # BUT: if the input has no recognisable section header anywhere (e.g. a
+    # bare role snippet fed to the parser by a unit test or a paste from a
+    # job-portal text box), fall back to the legacy default of starting in
+    # 'experience' so something gets parsed instead of nothing.
+    _text_lower = text.lower()
+    _has_any_section = any(
+        alias in _text_lower
+        for aliases in _SECTION_HEADERS.values()
+        for alias in aliases
+    )
+    section: Optional[str] = "preamble" if _has_any_section else "experience"
     current_role: Optional[Role] = None
     # Pool of date ranges seen before any role header (pdfminer column order).
     orphan_dates: list[tuple[str, str]] = []

--- a/.claude/skills/tailor-resume/scripts/profile_extractor.py
+++ b/.claude/skills/tailor-resume/scripts/profile_extractor.py
@@ -1559,10 +1559,27 @@ def _like_title_line(ln: str) -> bool:
 
 def _parse_plain_resume_text(text: str, source: str = "resume") -> Profile:
     """
-    Parse plain text extracted from PDF or DOCX.
-    Uses section-header detection + date-pattern heuristics to identify roles.
-    Supports 1-line (Title  Company  Date), 2-line (Title+Company / Date),
-    and 3-line (Title / Company / Date) role headers via 2-step lookahead.
+    Delegate to the modular `parsers.plain_parser._parse_plain_resume_text`.
+
+    This module's previous in-place implementation predated the parsers/
+    subpackage refactor and missed the Jake-template bug fixes from #106
+    (issues #101-#104). The duplicate body has been replaced with this
+    thin delegate so all callers — including legacy ones that imported
+    `_parse_plain_resume_text` from this module — automatically pick up
+    the up-to-date parser.
+
+    The pre-refactor body lives at `_parse_plain_resume_text_legacy`
+    below for any test that imports it directly.
+    """
+    from parsers.plain_parser import _parse_plain_resume_text as _impl
+    return _impl(text, source=source)
+
+
+def _parse_plain_resume_text_legacy(text: str, source: str = "resume") -> Profile:
+    """
+    Pre-#106 in-module implementation. Kept around in case any test imports it
+    directly; new callers should use `_parse_plain_resume_text` above which
+    routes to the modular `parsers.plain_parser` with the up-to-date fixes.
     """
     profile = Profile()
     # Fix OT1 en-dash encoded as ASCII 't' (LaTeX CMR font glyph 0x74).

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -19,13 +19,21 @@ if os.path.exists(_ROOT_ENV):
 # Path setup — must happen before any local imports
 # Tries .claude/skills path first (local dev), falls back to tailor_resume/_scripts
 # (installed package path), so the app works in both environments.
+#
+# NOTE: order in this list is intentional. `sys.path.insert(0, ...)` puts each
+# successive item at position 0, so the LAST item in this list ends up FIRST
+# in sys.path. We want `.claude/skills/.../scripts` to win because it holds
+# the modular `parsers/` subpackage with the up-to-date parser fixes.
+# The monolithic `tailor_resume/_scripts/profile_extractor.py` is the
+# pre-refactor fallback and should only be used when `.claude/` is missing
+# (e.g. when installed as a pip package from PyPI).
 # ---------------------------------------------------------------------------
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _REPO = os.path.dirname(_HERE)
 
 _SCRIPTS_CANDIDATES = [
-    os.path.join(_REPO, ".claude", "skills", "tailor-resume", "scripts"),
-    os.path.join(_REPO, "tailor_resume", "_scripts"),
+    os.path.join(_REPO, "tailor_resume", "_scripts"),                       # fallback
+    os.path.join(_REPO, ".claude", "skills", "tailor-resume", "scripts"),   # preferred (last → first in sys.path)
 ]
 for _p in _SCRIPTS_CANDIDATES:
     if os.path.isdir(_p) and _p not in sys.path:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,3 +1,5 @@
+# Streamlit Cloud cache-bust: 2026-05-17 — forces source refresh after #106/#108
+# (parser fixes + correct requirements.txt) didn't apply due to stale source cache.
 import sys
 import os
 

--- a/streamlit_app/tabs/profile_tab.py
+++ b/streamlit_app/tabs/profile_tab.py
@@ -4,10 +4,14 @@ import os
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _REPO = os.path.dirname(os.path.dirname(_HERE))
 
-# Ensure both script locations are on sys.path (same as app.py)
+# Ensure both script locations are on sys.path (same as app.py).
+# Order matters: sys.path.insert(0, ...) means the LAST item wins.
+# We want `.claude/skills/.../scripts` (which contains the modular parsers/
+# subpackage with up-to-date parser fixes) to take precedence over the
+# monolithic fallback at `tailor_resume/_scripts/profile_extractor.py`.
 for _p in [
-    os.path.join(_REPO, ".claude", "skills", "tailor-resume", "scripts"),
-    os.path.join(_REPO, "tailor_resume", "_scripts"),
+    os.path.join(_REPO, "tailor_resume", "_scripts"),                       # fallback
+    os.path.join(_REPO, ".claude", "skills", "tailor-resume", "scripts"),   # preferred
 ]:
     if os.path.isdir(_p) and _p not in sys.path:
         sys.path.insert(0, _p)


### PR DESCRIPTION
## Why
You reported that uploading `Naren_citi.pdf` to https://tailor-resume-ai.streamlit.app/ still returns the pre-#106 broken parse — even though we'd just merged #106 (parser fixes), #107 (deps), #108 (correct requirements.txt), and #109 (cache-bust). Pasted output was the **exact** bug pattern from #101-#104 we'd already fixed.

I reproduced the user's import path locally and found two stacked bugs preventing the #106 fix from ever running on Streamlit Cloud.

## Bug 1 — `sys.path` insertion order in streamlit_app

`streamlit_app/app.py` and `streamlit_app/tabs/profile_tab.py` both do:

```python
for _p in [
    os.path.join(_REPO, ".claude", "skills", "tailor-resume", "scripts"),  # intended preferred
    os.path.join(_REPO, "tailor_resume", "_scripts"),                       # fallback
]:
    if os.path.isdir(_p) and _p not in sys.path:
        sys.path.insert(0, _p)
```

But `sys.path.insert(0, ...)` means the **LAST iteration wins**. So `tailor_resume/_scripts` ended up at sys.path[0] and `from profile_extractor import parse_pdf` loaded the wrong file. Reversed both lists.

## Bug 2 — `.claude/skills/.../profile_extractor.py` is monolithic, not a shim

`tailor_resume/_scripts/profile_extractor.py` is a 67KB monolithic file (pre-refactor). I assumed `.claude/skills/.../scripts/profile_extractor.py` was a thin shim re-exporting from `parsers/`, but it's also a 1823-line monolithic copy with its **own duplicate `_parse_plain_resume_text` at line 1560** that missed the #106 fixes entirely.

Replaced the duplicate body with:

```python
def _parse_plain_resume_text(text: str, source: str = "resume") -> Profile:
    """Delegate to the modular parsers.plain_parser version with the #106 fixes."""
    from parsers.plain_parser import _parse_plain_resume_text as _impl
    return _impl(text, source=source)
```

Pre-refactor body preserved as `_parse_plain_resume_text_legacy` in case any test imports it directly.

## Bug 3 (caught while fixing 1+2) — `_parse_plain_resume_text` regressed bare-snippet inputs

The #106 fix started the parser in `section = "preamble"` to skip the contact-block at the top of resumes. But this broke a unit test that fed a bare role snippet with no section headers — the parser stayed in preamble mode and skipped everything.

Added a heuristic: start in `"preamble"` only when the input contains a recognised section header anywhere; otherwise fall back to the legacy default of `"experience"`.

## Verification

End-to-end repro of Streamlit's import path against `Naren_citi.pdf`:

```
Experience: 3 roles, total bullets: 10
  - Data Engineer @ ExponentHR (July 2024-Present)        [5 bullets]
  - Data Engineer @ Missouri S&T (Aug. 2023-July 2024)    [3 bullets]
  - Business Analyst @ Zomato (Mar. 2018-Sept. 2020)      [2 bullets]
Projects: 2
  - Real-Time Fraud Detection Pipeline                     [2 bullets]
  - JobScout – Automated Data Integration Platform         [1 bullet]
```

That's the correct parse.

## Tests
- Full suite: **974 passing** (same as before), 3 pre-existing web_api state-pollution failures unrelated.
- `test_pdfminer_extractor_unicode_endash` (which was the new-failure I introduced) now passes after the bug-3 heuristic.
- Lint clean.

## After merge
You reboot the Streamlit app one more time. `Naren_citi.pdf` should finally produce the correct 3-role / 10-bullet / 2-project profile.

Closes the loop on the original "PDF not being parsed" report.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mR8uF7ZYAnz9VkZ43Ps8d)_